### PR TITLE
Remove empty strings in linting command

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 					"default": [],
                     "description": "Specifies folder paths to be used as include path for the Fortran linter"
                 },
-                "fortran.gfortraExecutable": {
+                "fortran.gfortranExecutable": {
                    "type": "string",
                    "default": "gfortran",
                     "description": "Specifies the complete path of the gfortran executable"

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -33,12 +33,10 @@ export default class FortranLintingProvider {
 			...args,
 			getIncludeParams(includePaths), // include paths
 		 	textDocument.fileName
-			 ];
+			];
 
 		for (var i=argList.length-1; i>=0; i--) {
-    		if (argList[i] === "") {
-        		argList.splice(i, 1);
-    		}
+    		if (argList[i] === "") {argList.splice(i, 1);}
 		}
 
 		let childProcess = cp.spawn(command, argList);
@@ -51,8 +49,7 @@ export default class FortranLintingProvider {
 				decoded += data;
 			});
 			childProcess.stderr.on('end', () => {
-				let decodedOriginal =  decoded;
-				var matchesArray
+				let matchesArray:string[]
 				while ((matchesArray = errorRegex.exec(decoded)) !== null) {
   					let elements: string[] = matchesArray.slice(1); // get captured expressions
 					let startLine =  parseInt(elements[1]);
@@ -65,8 +62,8 @@ export default class FortranLintingProvider {
 					let diagnostic = new vscode.Diagnostic(range,message , severity);
 					diagnostics.push(diagnostic)
 				}
-			
-				 this.diagnosticCollection.set(textDocument.uri, diagnostics);
+
+				this.diagnosticCollection.set(textDocument.uri, diagnostics);
 			});
 			childProcess.stdout.on('close', code => {
 				console.log(`child process exited with code ${code}`);

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -28,11 +28,20 @@ export default class FortranLintingProvider {
 		let args = [...this.getLinterExtraArgs(), "-cpp", "-fsyntax-only", '-fdiagnostics-show-option'];
 		let includePaths = this.getIncludePaths();
 		let command = this.getGfortranPath();
-
-		let childProcess = cp.spawn(command, [
+		
+		let argList = [
 			...args,
 			getIncludeParams(includePaths), // include paths
-		 	textDocument.fileName]);
+		 	textDocument.fileName
+			 ];
+
+		for (var i=argList.length-1; i>=0; i--) {
+    		if (argList[i] === "") {
+        		argList.splice(i, 1);
+    		}
+		}
+
+		let childProcess = cp.spawn(command, argList);
 			 
 		if (childProcess.pid) {
 			childProcess.stdout.on('data', (data: Buffer) => {
@@ -43,8 +52,7 @@ export default class FortranLintingProvider {
 			});
 			childProcess.stderr.on('end', () => {
 				let decodedOriginal =  decoded;
-				
-				let matchesArray:string[];
+				var matchesArray
 				while ((matchesArray = errorRegex.exec(decoded)) !== null) {
   					let elements: string[] = matchesArray.slice(1); // get captured expressions
 					let startLine =  parseInt(elements[1]);
@@ -58,7 +66,7 @@ export default class FortranLintingProvider {
 					diagnostics.push(diagnostic)
 				}
 			
-				this.diagnosticCollection.set(textDocument.uri, diagnostics);
+				 this.diagnosticCollection.set(textDocument.uri, diagnostics);
 			});
 			childProcess.stdout.on('close', code => {
 				console.log(`child process exited with code ${code}`);


### PR DESCRIPTION
The linter wasn't working for me, and I think the problem is that my `includePaths` is an empty string (default setting) - which makes `cp.spawn()` angry.

I added a check to make sure that no arguments are an empty string, and now the linter works when testing on a simple 'hello world' program.

Also fixed a minor typo - and ironically made a typo when writing the commit message. :)