### PR TITLE
Make linter work in Windows

### DIFF
--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -16,7 +16,7 @@ export default class FortranLintingProvider {
 
     private diagnosticCollection: vscode.DiagnosticCollection;
     private doModernFortranLint(textDocument: vscode.TextDocument) {
-        const errorRegex: RegExp = /^([^:]*):([0-9]+):([0-9]+):\n\s(.*)\n.*\n(Error|Warning|Fatal Error):\s(.*)$/gm;
+        const errorRegex: RegExp = /^.{2}([^:]*):([0-9]+):([0-9]+):\r?\n\s*(.*)\r?\n.*\r?\n(Error|Warning|Fatal Error):\s(.*)$/gm;;
 
         if (textDocument.languageId !== LANGUAGE_ID) {
             return;

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -28,10 +28,15 @@ export default class FortranLintingProvider {
         let includePaths = this.getIncludePaths();
         let command = this.getGfortranPath();
 
-        let childProcess = cp.spawn(command, [
-            ...args,
-            getIncludeParams(includePaths), // include paths
-            textDocument.fileName]);
+        let argList = [
+			...args,
+			getIncludeParams(includePaths), // include paths
+		 	textDocument.fileName
+			];
+
+        argList = argList.map( arg => arg.trim()).filter(arg => arg !== "");
+
+        let childProcess = cp.spawn(command, argList)
 
         if (childProcess.pid) {
             childProcess.stdout.on('data', (data: Buffer) => {
@@ -41,8 +46,6 @@ export default class FortranLintingProvider {
                 decoded += data;
             });
             childProcess.stderr.on('end', () => {
-                let decodedOriginal = decoded;
-
                 let matchesArray: string[];
                 while ((matchesArray = errorRegex.exec(decoded)) !== null) {
                     let elements: string[] = matchesArray.slice(1); // get captured expressions


### PR DESCRIPTION
**Changes:**

- modified `errorRegex` to work on windows - the problem with the original regex was:
  1. it captured the ':' after the drive letter in the path, because windows paths are `c:/path/to/code.f`. The current solution is to skip the first two characters.
  2. line endings in windows are sometimes `\r\n` instead of `\n`. The new regex can handle both cases.
- made changes requested in #2 
- removed `decodedOriginal` because it doesn't appear to be used

I ran the tests on linux (arch) and windows 10, and all 13 tests passed. 
I also checked a simple 'hello world' script and the linter appears to work on both linux and windows - not sure about Macs, don't have one of those to test on. 