### PR TITLE
Update Linter for Windows

### DIFF
--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -19,7 +19,7 @@ export default class FortranLintingProvider {
     private doModernFortranLint(textDocument: vscode.TextDocument) {
 
 
-        const errorRegex: RegExp = /^([A-Z]:\\)*([^:]*):([0-9]+):([0-9]+):\n+(.*)\n.*\n(Error|Warning|Fatal Error):\s(.*)$/gm;
+        const errorRegex: RegExp = /^([a-zA-Z]:\\)*([^:]*):([0-9]+):([0-9]+):\s+(.*)\s+.*?\s+(Error|Warning|Fatal Error):\s(.*)$/gm;
 
         if (textDocument.languageId !== LANGUAGE_ID) {
             return;

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -82,6 +82,9 @@ export const _loadDocString = (keyword: string) => {
 }
 
 export const getIncludeParams = (paths: string[]) => {
+    if (paths.length == 0) {
+        return ""
+    }
     return "-I " + paths.join(" ");
 };
 

--- a/syntaxes/fortran.tmLanguage
+++ b/syntaxes/fortran.tmLanguage
@@ -192,7 +192,7 @@
 			<key>comment</key>
 			<string>statements controling the flow of the program</string>
 			<key>match</key>
-			<string>\b(?i:(go\s*to|assign|to|if|then|else|elseif|end\s*if|continue|stop|pause|do|end\s*do|while|cycle))\b</string>
+			<string>\b(?i:(go\s*to|assign|to|if|then|else|elseif|end\s*if|continue|stop|pause|do|end\s*do|while|cycle|exit))\b</string>
 			<key>name</key>
 			<string>keyword.control.fortran</string>
 		</dict>


### PR DESCRIPTION
I was having some problems getting the gfortran-based linter to work on Windows 10 so I took a stab at fixing the problems. 

**Issues:**
1. If no include paths are specified in `fortran.includePaths` then `gfortran` to complains about no input files and exits
1. `errorRegex` fails to match `gfortran` output so no errors are displayed

**Changes:**
- Modified the `getIncludeParams` function in `src/lib/helper.ts` to check for the `paths` variable having a length of 0. In this case the function returns `""` instead of `"-I "`. The empty argument will then be removed by `constructArgumentList` in `src/features/linter-provider.ts`.
- Modified `errorRegex` in `src/features/linter-provider.ts` to allow for upper and lowercase drive names on Windows and to match all space between output lines via `\s+` instead of just `\n`. The change to matching space should allow the regex to work regardless of the operating system using carriage returns or not.

I ran the extension tests on my Windows 10 computer and all 13 passed. Unfortunately, I don't have quick access to a linux system for testing, but I can create a VM if necessary.
