### PR TITLE
Fortran90: Added missing intrinsics. Corrected logical highlight.

### DIFF
--- a/syntaxes/fortran.tmLanguage
+++ b/syntaxes/fortran.tmLanguage
@@ -165,7 +165,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\b(?i:(integer|real|double\s+precision|complex|logical|character))\b(?=.*::)</string>
+			<string>\b(?i:(integer|real|double\sprecision|complex|logical|character))\b(?=.*::)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -216,7 +216,7 @@
 			<key>comment</key>
 			<string>operators</string>
 			<key>match</key>
-			<string>((?&lt;!\=)\=(?!\=)|\-|\+|\/\/|\/|(?!^)\*|::)</string>
+			<string>((?&lt;!\=)\=(?!\=)|\-|\+|\/\/|\/(?!\=|\))|(?!^)\*|::)</string>
 			<key>name</key>
 			<string>keyword.operator.fortran</string>
 		</dict>
@@ -226,7 +226,7 @@
 			<key>match</key>
 			<string>(?i:(\.and\.|\.or\.|\.eq\.|\.lt\.|\.le\.|\.gt\.|\.ge\.|\.ne\.|\.not\.|\.eqv\.|\.neqv\.))</string>
 			<key>name</key>
-			<string>keyword.operator.logical.fortran</string>
+			<string>keyword.logical.operator.fortran</string>
 		</dict>
 		<dict>
 			<key>comment</key>
@@ -256,7 +256,7 @@
 			<key>comment</key>
 			<string>mathematical intrisics</string>
 			<key>match</key>
-			<string>\b(?i:(((acos|asin|atan|atan2|cos|cosh|exp|log|log10|sin|sinh|sqrt|tan|tanh)(?=\())|(random_number|random_seed)))\b</string>
+			<string>\b(?i:(((acos|asin|atan|atan2|cos|cosh|exp|log|log10|sin|sinh|sqrt|tan|tanh|abs)(?=\())|(random_number|random_seed)))\b</string>
 			<key>name</key>
 			<string>keyword.other.instrisic.math.fortran</string>
 		</dict>
@@ -304,7 +304,7 @@
 			<key>comment</key>
 			<string>other intrisics</string>
 			<key>match</key>
-			<string>\b(?i:(((dtime)(?=\())|(date_and_time|system_clock)))\b</string>
+			<string>\b(?i:(((dtime)(?=\())|(date_and_time|system_clock|cpu_time)))\b</string>
 			<key>name</key>
 			<string>keyword.other.instrisic.fortran</string>
 		</dict>
@@ -312,7 +312,7 @@
 			<key>comment</key>
 			<string>data specification</string>
 			<key>match</key>
-			<string>\b(?i:(integer|real|double\s+precision|complex|logical|character|block\sdata|operator|assignment))\b</string>
+			<string>\b(?i:(integer|real|double\sprecision|complex|logical|character|block\sdata|operator|assignment))\b</string>
 			<key>name</key>
 			<string>storage.type.fortran</string>
 		</dict>

--- a/syntaxes/fortran90.tmLanguage
+++ b/syntaxes/fortran90.tmLanguage
@@ -299,27 +299,43 @@
 		<dict>
 			<key>comment</key>
 			<string>logical operators in symbolic format</string>
-			<key>match</key>
-			<string>\b(\=\=|\/\=|\&gt;\=|\&gt;|\&lt;|\&lt;\=)\b</string>
+            <key>match</key>
+			<string>(?i:(\<\=|\>\=|\<|\>|\/\=|\=\=))</string>
 			<key>name</key>
-			<string>keyword.operator.logical.fortran.modern</string>
+			<string>keyword.logical.operator.fortran.modern</string>
 		</dict>
 		<dict>
 			<key>comment</key>
 			<string>operators</string>
 			<key>match</key>
-			<string>(\%|\=\&gt;)</string>
+			<string>(\%|\/\)|\(\/)</string>
 			<key>name</key>
-			<string>keyword.operator.fortran.modern</string>
+			<string>keyword.other.operator.fortran.modern</string>
 		</dict>
 		<dict>
 			<key>comment</key>
 			<string>numeric instrinsics</string>
 			<key>match</key>
-			<string>\b(?i:(ceiling|floor|modulo|abs|sin)(?=\())</string>
-			<key>name</key>
-			<string>keyword.other.instrinsic.numeric.fortran.modern</string>
+			<string>\b(?i:(ceiling|floor|modulo|isnan|idint|idnint|norm2|dsqrt)(?=\())</string>
+            <key>name</key>
+			<string>keyword.other.instrinsic.math.fortran.modern</string>
 		</dict>
+        <dict>
+            <key>comment</key>
+			<string>trigonometric instrinsics</string>
+            <key>match</key>
+			<string>\b(?i:(cabs|dabs|iabs|dcos|dcosd|dcosh|dacos|dacosd|dacosh|dsin|dsind|dsinh|dasin|dasind|dasinh|dtan|dtand|dtanh|datan|datan2|datan2d|datand|datanh)(?=\())</string>
+            <key>name</key>
+			<string>keyword.other.instrinsic.math.fortran.modern</string>
+        </dict>
+        <dict>
+            <key>comment</key>
+			<string>memory instrinsic functions</string>
+            <key>match</key>
+			<string>\b(?i:(move_alloc|malloc)(?=\())</string>
+			<key>name</key>
+			<string>keyword.other.instrinsic.math.fortran.modern</string>
+        </dict>
 		<dict>
 			<key>comment</key>
 			<string>matrix/vector/array instrinsics</string>


### PR DESCRIPTION
These are the changes i told you i'd make. I tested and it seems to work well.
As told before, the conflict of `allocatable` declaration and `::` operator I could't fix so far.

Main Changes made:
- Add missing fortran90 intrinsics
- Corrected logical operators miss highlight


