### PR TITLE
+ add indentation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,68 @@
 # Change Log
+
 All notable changes to this extension will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- Initial release
 
-## [0.4.0] - 2017-05-29 
-### Added 
-- Show docs for intrinsic functions on hover
-### Changed
-- Updated icon for the extension 
-- Fix bug on linter not working
+* Initial release
 
+## [0.4.0] - 2017-05-29
+
+### Added
+
+* Show docs for intrinsic functions on hover
+  ### Changed
+* Updated icon for the extension
+* Fix bug on linter not working
 
 ## [0.4.4] - 2017-07-03
-### Added 
-- Add support for old fortran languague
-### Fixed 
-- Fix bug #1
+
+### Added
+
+* Add support for old fortran languague
+  ### Fixed
+* Fix bug #1
 
 ## [0.4.5] - 2017-07-04
+
 ### Fixed
-- Fix intrinsic functions docs not loading
+
+* Fix intrinsic functions docs not loading
 
 ## [0.4.6] - 2017-07-04
+
 ### Added
-- Add support for user configuration settings
+
+* Add support for user configuration settings
 
 ## [0.5.0] - 2017-07-06
+
 ### Added
-- Add code autocompletion for intrinsic and in document declared functions
+
+* Add code autocompletion for intrinsic and in document declared functions
 
 ## [0.5.1] - 2017-07-06
+
 ### Added
-- Add  `Go -> Go to symbol in file` command support for functions 
+
+* Add `Go -> Go to symbol in file` command support for functions
 
 ## [0.5.2] - 2017-07-14
-### Fixed 
-- A bug in the regex to parse output errors from gfortran
-- Now the spawn command uses the directory of the file `gfortran` is analyzing
 
+### Fixed
+
+* A bug in the regex to parse output errors from gfortran
+* Now the spawn command uses the directory of the file `gfortran` is analyzing
+
+## [0.6.1] - 2018-01-01
+
+### Added
+
+* Autoindentation rules for code blocks (thx @graceyangfan for the feature request)
+
+### Fixed
+
+* Fixed some highlighting issues by @pedro-ricardo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * A bug in the regex to parse output errors from gfortran
 * Now the spawn command uses the directory of the file `gfortran` is analyzing
 
-## [0.6.1] - 2018-01-01
+## [0.6.2] - 2018-01-01
 
 ### Added
 

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -49,7 +49,7 @@
         ]
     ],
     "indentationRules": {
-        "increaseIndentPattern": "^[^!]*then\\s*(!.*)?$|^\\s*(program|subroutine|function|module|do|block|associate)\\b.*$|^\\s*(else|else\\s*if|elsewhere)\\b.*$",
+        "increaseIndentPattern": "^[^!]*(then\\s*(!.*)?$|\\s*(program|subroutine|function|module|do|block|associate)\\b.*|\\s*(else|else\\s*if|elsewhere)\\b.*)$",
         "decreaseIndentPattern": "^\\s*end\\s*(if|do)\\s*|^\\s*else\\b.*$|^\\s*end\\s(function|subroutine|module|program)"
     }
 }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,21 +1,55 @@
 {
-   "comments": {
-       "lineComment": "!"
-   },
-   "brackets": [
-       ["[", "]"],
-       ["(", ")"],
-       ["(/", "/)"]
-   ],
-   "autoClosingPairs": [
-       { "open": "[", "close": "]" },
-       { "open": "(", "close": ")" },
-       { "open": "(/", "close": "/)" }
-   ],
-   "surroundingPairs": [
-       ["[", "]"],
-       ["(", ")"],
-       ["'", "'"],
-       ["\"", "\""]
-   ]
+    "comments": {
+        "lineComment": "!"
+    },
+    "brackets": [
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ],
+        [
+            "(/",
+            "/)"
+        ]
+    ],
+    "autoClosingPairs": [
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "(",
+            "close": ")"
+        },
+        {
+            "open": "(/",
+            "close": "/)"
+        }
+    ],
+    "surroundingPairs": [
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ],
+        [
+            "'",
+            "'"
+        ],
+        [
+            "\"",
+            "\""
+        ]
+    ],
+    "indentationRules": {
+        "increaseIndentPattern": "^[^!]*then\\s*(!.*)?$|^\\s*(program|subroutine|function|module|do|block|associate)\\b.*$|^\\s*(else|else\\s*if|elsewhere)\\b.*$",
+        "decreaseIndentPattern": "^\\s*end\\s*(if|do)\\s*|^\\s*else\\b.*$|^\\s*end\\s(function|subroutine|module|program)"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,134 +1,110 @@
 {
-    "name": "linter-gfortran",
-    "displayName": "Modern Fortran",
-    "description": "Modern Fortran language support, including syntax highlighting and error detection.",
-    "version": "0.6.0",
-    "publisher": "krvajalm",
-    "engines": {
-        "vscode": "^1.10.0"
-    },
-    "icon": "images/icon.png",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/krvajalmiguelangel/vscode-fortran-support.git"
-    },
-    "categories": [
-        "Languages",
-        "Snippets",
-        "Linters"
+  "name": "linter-gfortran",
+  "displayName": "Modern Fortran",
+  "description":
+    "Modern Fortran language support, including syntax highlighting and error detection.",
+  "version": "0.6.1",
+  "publisher": "krvajalm",
+  "engines": {
+    "vscode": "^1.10.0"
+  },
+  "icon": "images/icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krvajalmiguelangel/vscode-fortran-support.git"
+  },
+  "categories": ["Languages", "Snippets", "Linters"],
+  "activationEvents": ["onLanguage:fortran90"],
+  "main": "./out/src/extension",
+  "contributes": {
+    "languages": [
+      {
+        "id": "fortran90",
+        "aliases": ["Fortran90", "fortran90"],
+        "extensions": [".f90", ".F90", ".f95", ".F95", ".f08", ".F08"],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "fortran",
+        "aliases": ["Fortran ", "fortran"],
+        "extensions": [".f", ".F", ".f77", ".F77", ".FPP"]
+      }
     ],
-    "activationEvents": [
-        "onLanguage:fortran90"
+    "grammars": [
+      {
+        "language": "fortran90",
+        "scopeName": "source.fortran.modern",
+        "path": "./syntaxes/fortran90.tmLanguage"
+      },
+      {
+        "language": "fortran",
+        "scopeName": "source.fortran",
+        "path": "./syntaxes/fortran.tmLanguage"
+      }
     ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "languages": [
-            {
-                "id": "fortran90",
-                "aliases": [
-                    "Fortran90",
-                    "fortran90"
-                ],
-                "extensions": [
-                    ".f90",
-                    ".F90",
-                    ".f95",
-                    ".F95"
-                ],
-                "configuration": "./language-configuration.json"
-            },
-            {
-                "id": "fortran",
-                "aliases": [
-                    "Fortran ",
-                    "fortran"
-                ],
-                "extensions": [
-                    ".f",
-                    ".F",
-                    ".f77",
-                    ".F77",
-                    ".FPP"
-                ]
-            }
-        ],
-        "grammars": [
-            {
-                "language": "fortran90",
-                "scopeName": "source.fortran.modern",
-                "path": "./syntaxes/fortran90.tmLanguage"
-            },
-            {
-                "language": "fortran",
-                "scopeName": "source.fortran",
-                "path": "./syntaxes/fortran.tmLanguage"
-            }
-        ],
-        "snippets": [
-            {
-                "language": "fortran90",
-                "path": "./snippets/fortran90.json"
-            }
-        ],
-        "configuration": {
-            "type": "object",
-            "title": "Fortran configuration",
-            "properties": {
-                "fortran.includePaths": {
-                    "type": [
-                        "array"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "description": "Specifies folder paths to be used as include path for the Fortran linter"
-                },
-                "fortran.gfortranExecutable": {
-                    "type": "string",
-                    "default": "gfortran",
-                    "description": "Specifies the complete path of the gfortran executable"
-                },
-                "fortran.linterEnabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enables or disables the linter functionality"
-                },
-                "fortran.linterExtraArgs": {
-                    "type": [
-                        "array"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "-Wall"
-                    ],
-                    "description": "Specify additional options to use when calling the gfortran compiler"
-                }
-            }
+    "snippets": [
+      {
+        "language": "fortran90",
+        "path": "./snippets/fortran90.json"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Fortran configuration",
+      "properties": {
+        "fortran.includePaths": {
+          "type": ["array"],
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description":
+            "Specifies folder paths to be used as include path for the Fortran linter"
+        },
+        "fortran.gfortranExecutable": {
+          "type": "string",
+          "default": "gfortran",
+          "description":
+            "Specifies the complete path of the gfortran executable"
+        },
+        "fortran.linterEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enables or disables the linter functionality"
+        },
+        "fortran.linterExtraArgs": {
+          "type": ["array"],
+          "items": {
+            "type": "string"
+          },
+          "default": ["-Wall"],
+          "description":
+            "Specify additional options to use when calling the gfortran compiler"
         }
-    },
-    "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test",
-        "lint": "node ./node_modules/tslint/bin/tslint ./src/*.ts ./src/debugAdapter/*.ts ./test/*.ts"
-    },
-    "devDependencies": {
-        "@types/glob": "^5.0.30",
-        "@types/fs-extra": "0.0.35",
-        "fs-extra": "^1.0.0",
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.3",
-        "mocha": "^2.3.3",
-        "decache": "^4.1.0",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32",
-        "glob": "^7.1.1",
-        "istanbul": "^0.4.5",
-        "remap-istanbul": "^0.8.4",
-        "tslint": "^4.0.2"
+      }
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "node ./node_modules/vscode/bin/test",
+    "lint":
+      "node ./node_modules/tslint/bin/tslint ./src/*.ts ./src/debugAdapter/*.ts ./test/*.ts"
+  },
+  "devDependencies": {
+    "@types/glob": "^5.0.30",
+    "@types/fs-extra": "0.0.35",
+    "fs-extra": "^1.0.0",
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.3",
+    "mocha": "^2.3.3",
+    "decache": "^4.1.0",
+    "@types/node": "^6.0.40",
+    "@types/mocha": "^2.2.32",
+    "glob": "^7.1.1",
+    "istanbul": "^0.4.5",
+    "remap-istanbul": "^0.8.4",
+    "tslint": "^4.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Modern Fortran",
   "description":
     "Modern Fortran language support, including syntax highlighting and error detection.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "krvajalm",
   "engines": {
     "vscode": "^1.10.0"

--- a/vsc-extension-quickstart.md
+++ b/vsc-extension-quickstart.md
@@ -1,33 +1,38 @@
 # Welcome to your first VS Code Extension
 
 ## What's in the folder
+
 * This folder contains all of the files necessary for your extension
 * `package.json` - this is the manifest file in which you declare your extension and command.
-The sample plugin registers a command and defines its title and command name. With this information
-VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
+  The sample plugin registers a command and defines its title and command name. With this information
+  VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
 * `src/extension.ts` - this is the main file where you will provide the implementation of your command.
-The file exports one function, `activate`, which is called the very first time your extension is
-activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
-We pass the function containing the implementation of the command as the second parameter to
-`registerCommand`.
+  The file exports one function, `activate`, which is called the very first time your extension is
+  activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
+  We pass the function containing the implementation of the command as the second parameter to
+  `registerCommand`.
 
 ## Get up and running straight away
+
 * press `F5` to open a new window with your extension loaded
 * run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`
 * set breakpoints in your code inside `src/extension.ts` to debug your extension
 * find output from your extension in the debug console
 
 ## Make changes
+
 * you can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`
 * you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
 
 ## Explore the API
+
 * you can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`
 
 ## Run tests
+
 * open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`
 * press `F5` to run the tests in a new window with your extension loaded
 * see the output of the test result in the debug console
 * make changes to `test/extension.test.ts` or create new test files inside the `test` folder
-    * by convention, the test runner will only consider files matching the name pattern `**.test.ts`
-    * you can create folders inside the `test` folder to structure your tests any way you want
+  * by convention, the test runner will only consider files matching the name pattern `**.test.ts`
+  * you can create folders inside the `test` folder to structure your tests any way you wants


### PR DESCRIPTION
In version [v1.14](https://code.visualstudio.com/updates/v1_14#_auto-indent-on-type-move-lines-and-paste) of Visual Studio Code was added support for indentation rules. 
This allow to auto indent the next line of code when pressing enter.

I have added some rules as an starter for this feature.

Fixes: #15 

