### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import FortranHoverProvider from "./features/hover-provider";
 import { FortranCompletionProvider } from "./features/completion-provider";
 import { FortranDocumentSymbolProvider } from "./features/document-symbol-provider";
 
-const FORTRAN_FREE_FORM_ID = "fortran_free-form";
+const FORTRAN_FREE_FORM_ID = { language: "fortran_free-form", scheme: "file" };
 
 export function activate(context: vscode.ExtensionContext) {
   let hoverProvider = new FortranHoverProvider();

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -15,7 +15,7 @@ export default class FortranLintingProvider {
   private doModernFortranLint(textDocument: vscode.TextDocument) {
     const errorRegex: RegExp = /^([a-zA-Z]:\\)*([^:]*):([0-9]+):([0-9]+):\s+(.*)\s+.*?\s+(Error|Warning|Fatal Error):\s(.*)$/gm;
 
-    if (textDocument.languageId !== LANGUAGE_ID) {
+    if (textDocument.languageId !== LANGUAGE_ID || textDocument.uri.scheme !== "file") {
       return;
     }
     let decoded = "";


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Fortran, this PR simply updates the current `DocumentSelector` to be limited to local files. This way, when someone has the Fortran extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a Fortran project using Live Share, and doesn't have the Fortran extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Fortran extension installed. Additionally, this wouldn't impact the "local" Fortran development experience.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*