### PR TITLE
Fix minor Build errors

### DIFF
--- a/src/features/document-symbol-provider.ts
+++ b/src/features/document-symbol-provider.ts
@@ -57,7 +57,7 @@ export class FortranDocumentSymbolProvider
       }
     }
     return symbols;
-  };
+  }
 
   getSymbolsOfType(type: "subroutine" | "function" | "variable"): ParserFunc {
     switch (type) {
@@ -113,7 +113,7 @@ export class FortranDocumentSymbolProvider
       );
     }
   }
-  
+
   getSymbolTypes() {
     let config = vscode.workspace.getConfiguration("fortran");
     const symbolTypes = config.get<SymbolType[]>("symbols", [

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -18,7 +18,7 @@ export default class FortranLintingProvider {
     if (textDocument.languageId !== LANGUAGE_ID || textDocument.uri.scheme !== "file") {
       return;
     }
-    
+
     let decoded = "";
     let diagnostics: vscode.Diagnostic[] = [];
     let command = this.getGfortranPath();

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -2,9 +2,9 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 
-// IMPORTANT: this should match the value 
-// on the package.json otherwise the extension won't 
-// work at all ⛽️ 
+// IMPORTANT: this should match the value
+// on the package.json otherwise the extension won't
+// work at all
 export const LANGUAGE_ID = 'FortranFreeForm';
 
 export const intrinsics = [


### PR DESCRIPTION
Fix issue #58. Below the npm erros log:
```
src/features/document-symbol-provider.ts[116, 1]: trailing whitespace
src/features/document-symbol-provider.ts[60, 4]: Unnecessary semicolon
src/features/linter-provider.ts[21, 1]: trailing whitespace
src/lib/helper.ts[5, 42]: trailing whitespace
src/lib/helper.ts[6, 53]: trailing whitespace
src/lib/helper.ts[7, 18]: trailing whitespace
```
Build is now passing again.