### PR TITLE
Detect subroutine definitions without brackets

### DIFF
--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -75,7 +75,7 @@ export const parseSubroutine = (line: TextLine) => {
 };
 export const _parse = (line: TextLine, type: MethodType) => {
   const functionRegEx = /([a-zA-Z]+(\([\w.=]+\))*)*\s*function\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*\)\s*(result\([a-z_][\w]*\))*/i;
-  const subroutineRegEx = /subroutine\s*([a-z][a-z0-9_]*)\s*\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|&)/i;
+  const subroutineRegEx = /^\s*subroutine\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*\))*/i;
   const regEx =
     type === MethodType.Subroutine ? subroutineRegEx : functionRegEx;
 


### PR DESCRIPTION
Fixes issue #61 