### PR TITLE
Fix issue #71

### DIFF
--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -75,7 +75,7 @@ export const parseSubroutine = (line: TextLine) => {
 };
 export const _parse = (line: TextLine, type: MethodType) => {
   const functionRegEx = /([a-zA-Z]+(\([\w.=]+\))*)*\s*function\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*\)\s*(result\([a-z_][\w]*\))*/i;
-  const subroutineRegEx = /^\s*\bsubroutine\b\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|\&))*/i;
+  const subroutineRegEx = /^\s*(?!\bend\b)\w*\s*\bsubroutine\b\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|\&))*/i;
   const regEx =
     type === MethodType.Subroutine ? subroutineRegEx : functionRegEx;
 

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -75,7 +75,7 @@ export const parseSubroutine = (line: TextLine) => {
 };
 export const _parse = (line: TextLine, type: MethodType) => {
   const functionRegEx = /([a-zA-Z]+(\([\w.=]+\))*)*\s*function\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*\)\s*(result\([a-z_][\w]*\))*/i;
-  const subroutineRegEx = /^\s*subroutine\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*\))*/i;
+  const subroutineRegEx = /^\s*subroutine\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|\&))*/i;
   const regEx =
     type === MethodType.Subroutine ? subroutineRegEx : functionRegEx;
 

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -75,7 +75,7 @@ export const parseSubroutine = (line: TextLine) => {
 };
 export const _parse = (line: TextLine, type: MethodType) => {
   const functionRegEx = /([a-zA-Z]+(\([\w.=]+\))*)*\s*function\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*\)\s*(result\([a-z_][\w]*\))*/i;
-  const subroutineRegEx = /^\s*subroutine\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|\&))*/i;
+  const subroutineRegEx = /^\s*\bsubroutine\b\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|\&))*/i;
   const regEx =
     type === MethodType.Subroutine ? subroutineRegEx : functionRegEx;
 


### PR DESCRIPTION
Add the line break `&` back to the subroutine regex.
Symbols are now working correctly when subroutine have: no arguments, one line arguments and more than one line arguments.
Below is the screenshot that proves it:
![symb_working](https://user-images.githubusercontent.com/15893711/41465352-196dd854-7074-11e8-9699-0ac49daec983.png)
Thus fixing issue #71.
This change, along with PR #69 need to be released as 1.2.1 so other users can have their highlights corrected and their editor stop freezing.