### PR TITLE
Fix rule for highlighting logical fortran '<='

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -3352,7 +3352,7 @@
 		"assignment-operator": {
 			"comment": "Introduced in the Fortran 1977 standard.",
 			"name": "keyword.operator.assignment.fortran",
-			"match": "(?<!\\=)(\\=)(?!\\=|\\>)"
+			"match": "(?<!\\/|\\=|\\<|\\>)(\\=)(?!\\=|\\>)"
 		},
 		"derived-type-operators": {
 			"comment": "Introduced in the Fortran 1995 standard.",
@@ -3410,7 +3410,7 @@
 				{
 					"comment": "Introduced in the Fortran 1990 standard.",
 					"name": "keyword.logical.fortran.modern",
-					"match": "(\\=\\=|\\/\\=|\\>\\=|(?<!\\=)\\>|\\<|\\<\\=)"
+					"match": "(\\=\\=|\\/\\=|\\>\\=|(?<!\\=)\\>|\\<\\=|\\<)"
 				}
 			]
 		},


### PR DESCRIPTION
This commit fixes issue #73.
The changes include:
- Not add in scope `keyword.operator.assignment.fortran` the equal sign that is preceded by `/`, `<`,`>` or another `=`.
- Change order in regex rule, to match firstly `<=` than the `<` alone.

**Before:**  
![bug](https://user-images.githubusercontent.com/15893711/41495083-7d391a7a-70f5-11e8-8aee-960bd6ab3d8d.png)
**After:** 
 ![fix](https://user-images.githubusercontent.com/15893711/41495084-802ff67c-70f5-11e8-849f-fcca97697a56.png)