### PR TITLE
Revert syntax highlighting on all variables

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -5106,7 +5106,7 @@
 			]
 		},
 		"variable": {
-			"name": "variable.parameter.fortran",
+			"name": "meta.parameter.fortran",
 			"begin": "(?i)\\b(?=[a-z])",
 			"end": "(?<!\\G)",
 			"applyEndPatternLast": 1,


### PR DESCRIPTION
### Fixed
- Now all the variables are not highlighted by default 


