### PR TITLE
Subroutine arguments highlight improvement.

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -4794,11 +4794,11 @@
 			},
 			"patterns": [
 				{
-                    "include": "#dummy-variable"
-                },
-                {
-                    "include": "#line-continuation-operator"
-                }
+					"include": "#dummy-variable"
+				},
+				{
+					"include": "#line-continuation-operator"
+				}
 			]
 		},
 		"dummy-variable": {

--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -4786,7 +4786,7 @@
 					"name": "punctuation.definition.parameters.begin.fortran"
 				}
 			},
-			"end": "(\\)|(?=\\n))",
+			"end": "\\)",
 			"endCaptures": {
 				"0": {
 					"name": "punctuation.definition.parameters.end.fortran"

--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -4786,7 +4786,7 @@
 					"name": "punctuation.definition.parameters.begin.fortran"
 				}
 			},
-			"end": "\\)",
+			"end": "\\)|(?=\\n)",
 			"endCaptures": {
 				"0": {
 					"name": "punctuation.definition.parameters.end.fortran"
@@ -4794,8 +4794,11 @@
 			},
 			"patterns": [
 				{
-					"include": "#dummy-variable"
-				}
+                    "include": "#dummy-variable"
+                },
+                {
+                    "include": "#line-continuation-operator"
+                }
 			]
 		},
 		"dummy-variable": {


### PR DESCRIPTION
Stop ending the subroutine `dummy-variable-list` at line break and look for the next `)` to end it.
This fixes issue #70.

It is important to notice that this fix suffers from the same problem as the string markers `'` and `""`.
Now the argument list starts once `(` is typed **in subroutine header** and only ends when the `)` is found.

So, just like the string ones, if you leave the braket open it will keep highlighting. But since Fortran does not allow an open braket on a subroutine I don't believe this is an issue.

### Fix checklist
- [x] Highlight multiple lines in `dummy-variable-list`
- [x] Modify rule to look for `&` character