### PR TITLE
Fix symbol list for functions

### DIFF
--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -74,7 +74,7 @@ export const parseSubroutine = (line: TextLine) => {
   return _parse(line, MethodType.Subroutine);
 };
 export const _parse = (line: TextLine, type: MethodType) => {
-  const functionRegEx = /([a-zA-Z]+(\([\w.=]+\))*)*\s*function\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*\)\s*(result\([a-z_][\w]*\))*/i;
+  const functionRegEx = /([a-zA-Z]+(\([\w.=]+\))*)*\s*\bfunction\b\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*(\)|\&)\s*(result\([a-z_][\w]*(\)|\&))*/i;
   const subroutineRegEx = /^\s*(?!\bend\b)\w*\s*\bsubroutine\b\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|\&))*/i;
   const regEx =
     type === MethodType.Subroutine ? subroutineRegEx : functionRegEx;


### PR DESCRIPTION
Fix issue #78.
This commit include the following changes in `functionRegEx` to symbol list:
* Add `\b` word bound character to avoid false positives with user variables.
* Replace search for `)` with `) or &` to mark functions with more than one line of arguments.
* No need to add the skip for `end` keyword due to the absence of brakets `( )` at `end` statements
* No need to apply the subroutine fix for 'no arguments' because a `function` with no argument list in invalid in fortran.