### PR TITLE
Add Forall construct highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-* Add syntax highlight for 'forall' construct (#82)
+### Added 
+* Syntax highlight for 'forall' construct (#82)
 
 ## [1.3.1] - 2018-06-26
 
@@ -14,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Subroutine and function on symbol list were failing with more than one line arguments (#71)
 * Minor syntax highlighting issues (#62, #73)
 
-## Added 
+### Added 
 * Implementation of OpenMP directives highlighting (#17)
 * Syntax highlight on multiple line of dummy arguments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this extension will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+* Add syntax highlight for 'forall' construct (#82)
+
 ## [1.3.1] - 2018-06-26
 
 ### Fixed

--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -1454,6 +1454,41 @@
 				}
 			]
 		},
+		"forall-construct": {
+			"comment": "Introduced in the Fortran 1995 standard.",
+			"contentName": "meta.block.forall.fortran",
+			"begin": "(?i)\\s*\\b(forall)\\b",
+			"beginCaptures":{
+				"1": {
+					"name": "keyword.control.forall.fortran"
+				}
+			},
+			"end": "(?i)\\s*\\b(end\\s*forall)\\b",
+			"endCaptures": {
+				"1": {
+					"name": "keyword.control.endforall.fortran"
+				}
+			},
+			"patterns":[
+				{
+					"comment": "Loop control.",
+					"name": "meta.loop-control.fortran",
+					"begin": "(?i)\\G(?!\\s*[;!\\n])",
+					"end": "(?=[;!\\n])",
+					"patterns":[
+						{
+							"include": "#parentheses"
+						},
+						{
+							"include": "#invalid-word"
+						}
+					]
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
 		"control-statements": {
 			"patterns": [
 				{


### PR DESCRIPTION
Import forall highlight rule from [Atom fortran extension](https://github.com/dparkins/language-fortran).
**Before:**
![before](https://user-images.githubusercontent.com/15893711/42120681-b96f30dc-7bf5-11e8-92d2-b883009c4d17.png)
**After:**
![after](https://user-images.githubusercontent.com/15893711/42120684-c008a496-7bf5-11e8-8ce1-121d107a7ff1.png)
