### PR TITLE
Fix wrong language of gfortran messages

### DIFF
--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -25,7 +25,11 @@ export default class FortranLintingProvider {
     let argList = this.constructArgumentList(textDocument);
 
     let filePath = path.parse(textDocument.fileName).dir;
-    let childProcess = cp.spawn(command, argList, { cwd: filePath });
+
+    let env = Object.create(process.env);
+    env.LC_ALL = 'en_US.UTF-8';
+    let childProcess = cp.spawn(command, argList, { cwd: filePath, env: env });
+
 
     if (childProcess.pid) {
       childProcess.stdout.on("data", (data: Buffer) => {

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -26,10 +26,18 @@ export default class FortranLintingProvider {
 
     let filePath = path.parse(textDocument.fileName).dir;
 
-    let env = Object.create(process.env);
-    env.LC_ALL = 'en_US.UTF-8';
+    /*
+     * reset localization settings to traditional C English behavior in case
+     * gfortran is set up to use the system provided localization information,
+     * so errorRegex can nevertheless be used to filter out errors and warnings
+     *
+     * see also: https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html
+     */
+    const env = {
+      ...process.env,
+      LC_ALL:'C'
+    };
     let childProcess = cp.spawn(command, argList, { cwd: filePath, env: env });
-
 
     if (childProcess.pid) {
       childProcess.stdout.on("data", (data: Buffer) => {

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -35,7 +35,7 @@ export default class FortranLintingProvider {
      */
     const env = {
       ...process.env,
-      LC_ALL:'C'
+      LC_ALL: 'C'
     };
     let childProcess = cp.spawn(command, argList, { cwd: filePath, env: env });
 


### PR DESCRIPTION
The parser regexp for the gfortran error and warning messages
does only capture English error messages.
To ensure gfortran outputs messages in English set the LC_ALL
environment variable when calling gfortran.