### PR TITLE
Add support to unlimited polymorphic highlight

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -4570,7 +4570,7 @@
 		"derived-type": {
 			"comment": "Introduced in the Fortran 1995 standard.",
 			"name": "meta.specification.type.derived.fortran",
-			"match": "(?i)\\b(?:(class)|(type))\\s*(\\()\\s*([a-z]\\w*)(\\))",
+			"match": "(?i)\\b(?:(class)|(type))\\s*(\\()\\s*(([a-z]\\w*)|\\*)\\s*(\\))",
 			"captures": {
 				"1": {
 					"name": "storage.type.class.fortran"


### PR DESCRIPTION
Fixes issue #106 
Now the example looks like below:
![fort2](https://user-images.githubusercontent.com/15893711/50903968-46b2e800-1406-11e9-917c-d1d9e2bf18aa.png)
The regex of `class` and `type` declarations where changed to accept the character `*`.
Only declarations where changed, definitions where **not**.
```
type *
            !Invalid definition
end type *

type(*)     !Valid declaration
```