### PR TITLE
Fix Select Case highlight

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -1278,7 +1278,7 @@
 			"patterns": [
 				{
 					"name": "meta.block.select.fortran",
-					"begin": "(?i)\\b(select)\\b",
+					"begin": "(?i)\\b(select\\s*case|selectcase)\\b",
 					"beginCaptures": {
 						"1": {
 							"name": "keyword.control.select.fortran"
@@ -1293,7 +1293,7 @@
 					"patterns": [
 						{
 							"comment": "Select case construct. Introduced in the Fortran 1990 standard.",
-							"begin": "(?i)\\G\\s*\\b(case)\\b",
+							"begin": "(?i)^\\s*\\b(case)\\b",
 							"beginCaptures": {
 								"1": {
 									"name": "keyword.control.case.fortran"


### PR DESCRIPTION
Fixes issue #110 by accepting `selectcase` `select case` statements as part of `keyword.control.select.fortran` scope and restrict `keyword.control.case.fortran` scope to `case` statement alone.

![screenshot_20190206_095558](https://user-images.githubusercontent.com/15893711/52340021-d5ab2400-29f5-11e9-84d4-f13be41baee4.png)
