### PR TITLE
Fix case sensitive indentation.

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -50,7 +50,13 @@
     ],
     "indentationRules": {
         "unIndentedLinePattern": "^\\s*!.*",
-        "increaseIndentPattern": "then(\\s*|\\s*!.*)$|^\\s*(program|subroutine|function|module|do|block|associate|case|select\\s*case)\\b.*$|\\s*(else|else\\s*if|elsewhere)\\b.*$",
-        "decreaseIndentPattern": "^\\s*end\\s*(select|if|do|function|subroutine|module|program)\\b.*$|^\\s*else|case\\b.*$"
+        "increaseIndentPattern": {
+            "pattern": "then(\\s*|\\s*!.*)$|^\\s*(program|subroutine|function|module|do|block|associate|case|select\\s*case)\\b.*$|\\s*(else|else\\s*if|elsewhere)\\b.*$",
+            "flags": "i"
+        },
+        "decreaseIndentPattern": {
+            "pattern": "^\\s*end\\s*(select|if|do|function|subroutine|module|program)\\b.*$|^\\s*else|case\\b.*$",
+            "flags": "i"
+        }
     }
 }


### PR DESCRIPTION
Indentation is now case insensitive, using flag `i` on RegExp.
Fixes issue #115 