### PR TITLE
Fix linter not work on Windows/MinGW-x64

### DIFF
--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -40,7 +40,7 @@ export default class FortranLintingProvider {
     if (process.platform == 'win32') {
       // Windows needs to know the path of other tools
       if (!env.Path.includes(path.dirname(command))) {
-        env.Path = `${path.dirname(command)}${path.delimiter}` + env.Path;
+        env.Path = `${path.dirname(command)}${path.delimiter}${env.Path}`;
       }
     }
     let childProcess = cp.spawn(command, argList, { cwd: filePath, env: env });

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -37,6 +37,12 @@ export default class FortranLintingProvider {
       ...process.env,
       LC_ALL: 'C'
     };
+    if (process.platform == 'win32') {
+      // Windows needs to know the path of other tools
+      if (!env.Path.includes(path.dirname(command))) {
+        env.Path = `${path.dirname(command)}${path.delimiter}` + env.Path;
+      }
+    }
     let childProcess = cp.spawn(command, argList, { cwd: filePath, env: env });
 
     if (childProcess.pid) {


### PR DESCRIPTION
In previous version, to make linter works on Windows, there are the following three requirements:
1. Install `MinGW-x64` version `gfortran` compiler. NOT MSYS2, NOT Cygwin. Only `MinGW-x64` can run natively on windows. You can install it by first install [mysys2](https://www.msys2.org/) and then run `pacman -Syu` and ` pacman -S mingw-w64-x86_64-toolchain`.
2. Add the `bin` directory to the `PATH` environment variable, for my case, it's `C:\msys64\mingw64\bin`
3. Add the path of `gfortran` to the `Gfortran Excutable`, for my case, it's `C:\msys64\mingw64\bin\gfortran.exe`

This PR removes the second requirement since editing `PATH` globally can ruin other program. The fix extracts the path of `bin` directory of `gfortran` and adds it to the `PATH` of `child_process`

Fix https://github.com/krvajal/vscode-fortran-support/issues/116