### PR TITLE
Temporary remove Experimental Language Fortran setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,18 +89,6 @@ This is a list of some of the snippets included, if you like to include addition
 ## Error wiggles
 
 To trigger code validations you must save the file first.
-<!-- 
-## Fortran Language Server (Experimental)
-
-This extension uses a host of tools to provide the various language features. An alternative is to use a single language server that provides the same feature.
-
-Set `fortran.useLanguageServer` to `true` to use the Fortran language server from [Chris Hansen](https://github.com/hansec/fortran-language-server) for features like Hover, Definition, Find All References, Signature Help, Go to Symbol in File and Workspace.
-
-- This is an experimental feature and is not available in Windows yet.
-- Since only a single language server is spun up for given VS Code instance, having multi-root setup does not work
-- If set to true, you will be prompted to install the Fortran language server. Once installed, you will have to reload VS Code window. The language server will then be run by the Fortran extension in the background to provide services needed for the above mentioned features.
-- Every time you change the value of the setting `fortran.useLanguageServer`, you need to reload the VS Code window for it to take effect.
--->
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This is a list of some of the snippets included, if you like to include addition
 ## Error wiggles
 
 To trigger code validations you must save the file first.
-
+<!-- 
 ## Fortran Language Server (Experimental)
 
 This extension uses a host of tools to provide the various language features. An alternative is to use a single language server that provides the same feature.
@@ -100,6 +100,7 @@ Set `fortran.useLanguageServer` to `true` to use the Fortran language server fro
 - Since only a single language server is spun up for given VS Code instance, having multi-root setup does not work
 - If set to true, you will be prompted to install the Fortran language server. Once installed, you will have to reload VS Code window. The language server will then be run by the Fortran extension in the background to provide services needed for the above mentioned features.
 - Every time you change the value of the setting `fortran.useLanguageServer`, you need to reload the VS Code window for it to take effect.
+-->
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -133,11 +133,6 @@
           ],
           "description": "Specify what kind of symbols should be shown by the symbols' provider"
         },
-        "fortran.useLanguageServer": {
-          "type": "boolean",
-          "default": false,
-          "description": "Experimental: Not available in Windows. Use Fortran language server from hansec for Hover, Definition, Find All References, Signature Help, File Outline and Workspace Symbol features"
-        },
         "fortran.preferredCase": {
           "type": "string",
           "default": "lowercase",

--- a/src/lang-server.ts
+++ b/src/lang-server.ts
@@ -50,7 +50,7 @@ export class FortranLangServer {
 }
 
 export function checkForLangServer(config) {
-  const useLangServer = config.get('useLanguageServer')
+  const useLangServer = false //config.get('useLanguageServer')
   if (!useLangServer) return false
   if (process.platform === 'win32') {
     vscode.window.showInformationMessage(


### PR DESCRIPTION
Follow a recommendation from #105 to avoid issues like #114 #119.
Users are trying to use the feature and getting errors, also the [FORTRAN IntelliSense](https://marketplace.visualstudio.com/items?itemName=hansec.fortran-ls) extension exists to add that support.
### Steps
- [x] The **README.md** part was commented
- [x] The setting on **package.json** was removed
- [x] The usage of this configuration in **lang-server.ts** was commented and hard-coded as `false`