### PR TITLE
Highlight Fixes

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -1236,7 +1236,7 @@
 									"patterns": [
 										{
 											"comment": "rest of else line",
-											"begin": "(?!(\\s*!)|(\\s*\\n))",
+											"begin": "(?!(\\s*(;|!|\\n)))",
 											"end": "(?=[;!\\n])",
 											"patterns": [
 												{

--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -4064,7 +4064,7 @@
 		},
 		"type-specification-statements": {
 			"name": "meta.specification.type.fortran",
-			"begin": "(?ix)(?=\\b(?:character|class|complex|double\\s*precision|double\\s*complex|integer|logical|real|type)\\b(?![^'\";!\\n]*\\bfunction\\b))",
+			"begin": "(?ix)(?=\\b(?:character|class|complex|double\\s*precision|double\\s*complex|integer|logical|real|type|dimension)\\b(?![^'\";!\\n]*\\bfunction\\b))",
 			"end": "(?=[\\);!\\n])",
 			"patterns": [
 				{
@@ -4670,7 +4670,7 @@
 					]
 				},
 				{
-					"match": "(?ix)\\b(?:(complex)|(double\\s*precision)|(double\\s*complex)|(integer)|(real))\\b(?:\\s*(\\*)\\s*(\\d*))?",
+					"match": "(?ix)\\b(?:(complex)|(double\\s*precision)|(double\\s*complex)|(integer)|(real)|(dimension))\\b(?:\\s*(\\*)\\s*(\\d*))?",
 					"captures": {
 						"1": {
 							"name": "storage.type.complex.fortran"
@@ -4688,9 +4688,12 @@
 							"name": "storage.type.real.fortran"
 						},
 						"6": {
+							"name": "storage.type.dimension.fortran"
+							},
+						"7": {
 							"name": "keyword.operator.multiplication.fortran"
 						},
-						"7": {
+						"8": {
 							"name": "constant.numeric.fortran"
 						}
 					}

--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -1278,7 +1278,7 @@
 			"patterns": [
 				{
 					"name": "meta.block.select.fortran",
-					"begin": "(?i)\\b(select\\s*case|selectcase)\\b",
+					"begin": "(?i)\\b(select)",
 					"beginCaptures": {
 						"1": {
 							"name": "keyword.control.select.fortran"
@@ -1293,7 +1293,7 @@
 					"patterns": [
 						{
 							"comment": "Select case construct. Introduced in the Fortran 1990 standard.",
-							"begin": "(?i)^\\s*\\b(case)\\b",
+							"begin": "(?i)\\s*(case)\\b",
 							"beginCaptures": {
 								"1": {
 									"name": "keyword.control.case.fortran"
@@ -1336,10 +1336,10 @@
 						},
 						{
 							"comment": "Select type construct. Introduced in the Fortran 2003 standard.",
-							"begin": "(?i)\\G\\s*\\b(type)\\b",
+							"begin": "(?i)\\s*(type)\\b",
 							"beginCaptures": {
 								"1": {
-									"name": "keyword.control.case.fortran"
+									"name": "keyword.control.type.fortran"
 								}
 							},
 							"end": "(?i)(?=\\b(end\\s*select)\\b)",
@@ -1348,7 +1348,7 @@
 									"include": "#parentheses"
 								},
 								{
-									"begin": "(?i)\\b(?:(class)|(type))\\b",
+									"begin": "(?i)\\b(?:(class)|(type))",
 									"beginCaptures": {
 										"1": {
 											"name": "keyword.control.class.fortran"
@@ -1368,7 +1368,7 @@
 											}
 										},
 										{
-											"match": "(?i)\\G\\s*\\b(is)\\b",
+											"match": "(?i)\\G\\s*(is)\\b",
 											"captures": {
 												"1": {
 													"name": "keyword.control.is.fortran"


### PR DESCRIPTION
This commits fix issues #128 and #127 

#### The dimension highlight on F77 looks like this (#127):
![Screenshot_20190416_163439](https://user-images.githubusercontent.com/15893711/56238775-a6540b80-6065-11e9-9a44-f82642125669.png)

#### The select type highlight on F08 looks like this (#128):
![Screenshot_20190416_163458](https://user-images.githubusercontent.com/15893711/56238783-ac49ec80-6065-11e9-82f4-777a2faf3408.png)

#### The else highlight with end-line operator `;` looks like this (#137):
![Screenshot_20190608_162158](https://user-images.githubusercontent.com/15893711/59151450-bb1ba280-8a09-11e9-80a4-c8c2d04bc8c2.png)
