### PR TITLE
Map Fortran subroutines to vscode Function kind

### DIFF
--- a/src/features/document-symbol-provider.ts
+++ b/src/features/document-symbol-provider.ts
@@ -80,7 +80,7 @@ export class FortranDocumentSymbolProvider
         let range = new vscode.Range(line.range.start, line.range.end);
         return new vscode.SymbolInformation(
           fun.name,
-          vscode.SymbolKind.Method,
+          vscode.SymbolKind.Function,
           range
         );
       }


### PR DESCRIPTION
Fixes #140.

The LSP doesn't offer different symbol kinds that would map neatly to Fortran subroutines and functions. Currently, subroutines are mapped to `method` and functions to `function`. As discussed in #140 this has the wrong semantics since `method` should refer to a procedure that's associated with an object (in Fortran type-bound procedure) whereas function does not have that association. This PR maps subroutines to `function` as well. Note that this does not affect the icon but merely the tooltip in the outline or the breadcrumb.