### PR TITLE
Fix blocking due to very slow regex execution in "parseFunction"

### DIFF
--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -74,7 +74,7 @@ export const parseSubroutine = (line: TextLine) => {
   return _parse(line, MethodType.Subroutine);
 };
 export const _parse = (line: TextLine, type: MethodType) => {
-  const functionRegEx = /([a-zA-Z]+(\([\w.=]+\))*)*\s*\bfunction\b\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*(\)|\&)\s*(result\([a-z_][\w]*(\)|\&))*/i;
+  const functionRegEx = /(?<=([a-zA-Z]+(\([\w.=]+\))*)*)\s*\bfunction\b\s*([a-zA-Z_][a-z0-9_]*)\s*\((\s*[a-z_][a-z0-9_,\s]*)*\s*(?:\)|\&)\s*(result\([a-z_][\w]*(?:\)|\&))*/i;
   const subroutineRegEx = /^\s*(?!\bend\b)\w*\s*\bsubroutine\b\s*([a-z][a-z0-9_]*)\s*(?:\((\s*[a-z][a-z0-9_,\s]*)*\s*(\)|\&))*/i;
   const regEx =
     type === MethodType.Subroutine ? subroutineRegEx : functionRegEx;


### PR DESCRIPTION
With long function names the current regex is very slow, effectively blocking symbols from being displayed in the outline view. Below is a minimal example based on [Fortran Intellisense issue #19](https://github.com/hansec/vscode-fortran-ls/issues/19).

```fortran
subroutine longsubroutinenamesuchasthisname(pos1,pos2,pos3) ! function
integer, intent(in) :: pos1,pos2,pos3,longvarname
end subroutine
``` 