### PR TITLE
Add support for disabling Hover, Completion and Symbol providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
           ],
           "description": "Specify additional options to use when calling the gfortran compiler"
         },
+        "fortran.provideSymbols": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enables or disables symbol functionality (disable if using 'Fortran IntelliSense')"
+        },
         "fortran.symbols": {
           "type": [
             "array"
@@ -132,6 +137,16 @@
             "subroutine"
           ],
           "description": "Specify what kind of symbols should be shown by the symbols' provider"
+        },
+        "fortran.provideHover": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enables or hover functionality (disable if using 'Fortran IntelliSense')"
+        },
+        "fortran.provideCompletion": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enables or disables completion functionality (disable if using 'Fortran IntelliSense')"
         },
         "fortran.preferredCase": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,6 @@ import { FortranLangServer, checkForLangServer } from './lang-server'
 
 
 export function activate(context: vscode.ExtensionContext) {
-  let hoverProvider = new FortranHoverProvider()
-  let completionProvider = new FortranCompletionProvider()
-  let symbolProvider = new FortranDocumentSymbolProvider()
 
   const extensionConfig = vscode.workspace.getConfiguration(EXTENSION_ID)
 
@@ -23,17 +20,30 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerCodeActionsProvider(FORTRAN_FREE_FORM_ID, linter)
   }
 
-  vscode.languages.registerCompletionItemProvider(
-    FORTRAN_FREE_FORM_ID,
-    completionProvider
-  )
-  vscode.languages.registerHoverProvider(FORTRAN_FREE_FORM_ID, hoverProvider)
+  if (extensionConfig.get('provideCompletion', true)) {
+    let completionProvider = new FortranCompletionProvider()
+    vscode.languages.registerCompletionItemProvider(
+      FORTRAN_FREE_FORM_ID,
+      completionProvider
+    )
+  }
 
-  vscode.languages.registerDocumentSymbolProvider(
-    FORTRAN_FREE_FORM_ID,
-    symbolProvider
-  )
-  
+  if (extensionConfig.get('provideHover', true)) {
+    let hoverProvider = new FortranHoverProvider()
+    vscode.languages.registerHoverProvider(
+      FORTRAN_FREE_FORM_ID,
+      hoverProvider
+    )
+  }
+
+  if (extensionConfig.get('provideSymbols', true)) {
+    let symbolProvider = new FortranDocumentSymbolProvider()
+    vscode.languages.registerDocumentSymbolProvider(
+      FORTRAN_FREE_FORM_ID,
+      symbolProvider
+    )
+  }
+
   if (checkForLangServer(extensionConfig)) {
 
     const langServer = new FortranLangServer(context, extensionConfig)


### PR DESCRIPTION
When using other extensions that provide symbols, completion, etc. such as the [Fortran Intellisense extension](https://github.com/hansec/vscode-fortran-ls) duplicate symbols and other information can be confusing.