### PR TITLE
Fix symbols in newer versions

### DIFF
--- a/src/features/document-symbol-provider.ts
+++ b/src/features/document-symbol-provider.ts
@@ -44,7 +44,6 @@ export class FortranDocumentSymbolProvider
 
     for (let i = 0; i < lines; i++) {
       let line: vscode.TextLine = document.lineAt(i);
-      line = { ...line, text: line.text.trim() };
       if (line.isEmptyOrWhitespace) continue;
       let initialCharacter = line.text.trim().charAt(0);
       if (initialCharacter === "!" || initialCharacter === "#") continue;
@@ -75,11 +74,11 @@ export class FortranDocumentSymbolProvider
 
   private parseSubroutineDefinition(line: TextLine) {
     try {
-      const fun = getDeclaredSubroutine(line);
-      if (fun) {
+      const subroutine = getDeclaredSubroutine(line);
+      if (subroutine) {
         let range = new vscode.Range(line.range.start, line.range.end);
         return new vscode.SymbolInformation(
-          fun.name,
+          subroutine.name,
           vscode.SymbolKind.Method,
           range
         );
@@ -90,12 +89,11 @@ export class FortranDocumentSymbolProvider
   }
 
   private parseFunctionDefinition(line: TextLine) {
-    const subroutine = getDeclaredFunction(line);
-    if (subroutine) {
+    const fun = getDeclaredFunction(line);
+    if (fun) {
       let range = new vscode.Range(line.range.start, line.range.end);
-
       return new vscode.SymbolInformation(
-        subroutine.name,
+        fun.name,
         vscode.SymbolKind.Function,
         range
       );


### PR DESCRIPTION
For some reason, the following code:
```ts
line = { ...line, text: line.text.trim() };
```
Cause the variable `line` to lose the `TextLine` properties (such as `.range`) in VSCode newer versions.

This change in the `text` property is not needed, since it's already done whenever is used:
```ts
let initialCharacter = line.text.trim().charAt(0);
```
Therefore it was removed, and symbols started to work again.
