### PR TITLE
Fix select highlight after & operator

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -2110,6 +2110,9 @@
 									"include": "#invalid-word"
 								}
 							]
+						},
+						{
+							"include": "#line-continuation-operator"
 						}
 					]
 				},
@@ -4071,6 +4074,9 @@
 					"include": "#types"
 				},
 				{
+					"include": "#line-continuation-operator"
+				},
+				{
 					"comment": "Attribute list.",
 					"contentName": "meta.attribute-list.fortran",
 					"begin": "(?=\\s*(,|::))",
@@ -4148,6 +4154,9 @@
 									"include": "#invalid-word"
 								}
 							]
+						},
+						{
+							"include": "#line-continuation-operator"
 						}
 					]
 				},
@@ -4939,6 +4948,9 @@
 				},
 				{
 					"include": "#variable"
+				},
+				{
+					"include": "#line-continuation-operator"
 				}
 			]
 		},

--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -994,7 +994,13 @@
 					"include": "#if-construct"
 				},
 				{
-					"include": "#select-construct"
+					"include": "#select-case-construct"
+				},
+				{
+					"include": "#select-type-construct"
+				},
+				{
+					"include": "#select-rank-construct"
 				},
 				{
 					"include": "#where-construct"
@@ -1274,121 +1280,167 @@
 				}
 			]
 		},
-		"select-construct": {
+		"select-case-construct":{
+			"comment": "Select case construct. Introduced in the Fortran 1990 standard.",
+			"begin": "(?i)\\b(select)\\s*(case)\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.select.fortran"
+				},
+				"2": {
+					"name": "keyword.control.case.fortran"
+				}
+			},
+			"end": "(?i)(?=\\b(end\\s*select)\\b)",
+			"endCaptures": {
+				"1": {
+					"name": "keyword.control.endselect.fortran"
+				}
+			},
 			"patterns": [
 				{
-					"name": "meta.block.select.fortran",
-					"begin": "(?i)\\b(select)",
+					"include": "#parentheses"
+				},
+				{
+					"begin": "(?i)\\b(case)\\b",
 					"beginCaptures": {
 						"1": {
-							"name": "keyword.control.select.fortran"
+							"name": "keyword.control.case.fortran"
 						}
 					},
-					"end": "(?i)\\b(end\\s*select)\\b",
-					"endCaptures": {
-						"1": {
-							"name": "keyword.control.endselect.fortran"
-						}
-					},
+					"end": "(?i)(?=[;!\\n])",
 					"patterns": [
 						{
-							"comment": "Select case construct. Introduced in the Fortran 1990 standard.",
-							"begin": "(?i)\\s*(case)\\b",
-							"beginCaptures": {
+							"match": "(?i)\\G\\s*\\b(default)\\b",
+							"captures": {
 								"1": {
-									"name": "keyword.control.case.fortran"
+									"name": "keyword.control.default.fortran"
 								}
-							},
-							"end": "(?i)(?=\\b(end\\s*select)\\b)",
-							"patterns": [
-								{
-									"include": "#parentheses"
-								},
-								{
-									"begin": "(?i)\\b(case)\\b",
-									"beginCaptures": {
-										"1": {
-											"name": "keyword.control.case.fortran"
-										}
-									},
-									"end": "(?i)(?=[;!\\n])",
-									"patterns": [
-										{
-											"match": "(?i)\\G\\s*\\b(default)\\b",
-											"captures": {
-												"1": {
-													"name": "keyword.control.default.fortran"
-												}
-											}
-										},
-										{
-											"include": "#parentheses"
-										},
-										{
-											"include": "#invalid-word"
-										}
-									]
-								},
-								{
-									"include": "$base"
-								}
-							]
+							}
 						},
 						{
-							"comment": "Select type construct. Introduced in the Fortran 2003 standard.",
-							"begin": "(?i)\\s*(type)\\b",
-							"beginCaptures": {
-								"1": {
-									"name": "keyword.control.type.fortran"
-								}
-							},
-							"end": "(?i)(?=\\b(end\\s*select)\\b)",
-							"patterns": [
-								{
-									"include": "#parentheses"
-								},
-								{
-									"begin": "(?i)\\b(?:(class)|(type))",
-									"beginCaptures": {
-										"1": {
-											"name": "keyword.control.class.fortran"
-										},
-										"2": {
-											"name": "keyword.control.type.fortran"
-										}
-									},
-									"end": "(?i)(?=[;!\\n])",
-									"patterns": [
-										{
-											"match": "(?i)\\G\\s*\\b(default)\\b",
-											"captures": {
-												"1": {
-													"name": "keyword.control.default.fortran"
-												}
-											}
-										},
-										{
-											"match": "(?i)\\G\\s*(is)\\b",
-											"captures": {
-												"1": {
-													"name": "keyword.control.is.fortran"
-												}
-											}
-										},
-										{
-											"include": "#parentheses"
-										},
-										{
-											"include": "#invalid-word"
-										}
-									]
-								},
-								{
-									"include": "$base"
-								}
-							]
+							"include": "#parentheses"
+						},
+						{
+							"include": "#invalid-word"
 						}
 					]
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"select-type-construct":{
+			"comment": "Select type construct. Introduced in the Fortran 2003 standard.",
+			"begin": "(?i)\\b(select)\\s*(type)\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.select.fortran"
+				},
+				"2": {
+					"name": "keyword.control.type.fortran"
+				}
+			},
+			"end": "(?i)(?=\\b(end\\s*select)\\b)",
+			"endCaptures": {
+				"1": {
+					"name": "keyword.control.endselect.fortran"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#parentheses"
+				},
+				{
+					"begin": "(?i)\\b(?:(class)|(type))",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.class.fortran"
+						},
+						"2": {
+							"name": "keyword.control.type.fortran"
+						}
+					},
+					"end": "(?i)(?=[;!\\n])",
+					"patterns": [
+						{
+							"match": "(?i)\\G\\s*\\b(default)\\b",
+							"captures": {
+								"1": {
+									"name": "keyword.control.default.fortran"
+								}
+							}
+						},
+						{
+							"match": "(?i)\\G\\s*(is)\\b",
+							"captures": {
+								"1": {
+									"name": "keyword.control.is.fortran"
+								}
+							}
+						},
+						{
+							"include": "#parentheses"
+						},
+						{
+							"include": "#invalid-word"
+						}
+					]
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"select-rank-construct":{
+			"comment": "Select rank construct. Introduced in the Fortran 2008 standard.",
+			"begin": "(?i)\\b(select)\\s*(rank)\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.select.fortran"
+				},
+				"2": {
+					"name": "keyword.control.rank.fortran"
+				}
+			},
+			"end": "(?i)(?=\\b(end\\s*select)\\b)",
+			"endCaptures": {
+				"1": {
+					"name": "keyword.control.endselect.fortran"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#parentheses"
+				},
+				{
+					"begin": "(?i)\\b(rank)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.rank.fortran"
+						}
+					},
+					"end": "(?i)(?=[;!\\n])",
+					"patterns": [
+						{
+							"match": "(?i)\\G\\s*\\b(default)\\b",
+							"captures": {
+								"1": {
+									"name": "keyword.control.default.fortran"
+								}
+							}
+						},
+						{
+							"include": "#parentheses"
+						},
+						{
+							"include": "#invalid-word"
+						}
+					]
+				},
+				{
+					"include": "$base"
 				}
 			]
 		},


### PR DESCRIPTION
The error reported in #149 was in the `line-continuation-operator` pattern that was missing from both `name-list` and `attribute-list` scopes used in declaration statements.
### Before this change:
![Screenshot_2020-02-24_20-42-50](https://user-images.githubusercontent.com/15893711/75201151-6dd19380-5746-11ea-88c2-f167a3f36538.png)
### After this change:
![Screenshot_2020-02-24_20-43-29](https://user-images.githubusercontent.com/15893711/75201171-817cfa00-5746-11ea-902e-e9022dd7322b.png)
