### PR TITLE
Fix in-line forall highlighting

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -1456,26 +1456,21 @@
 		},
 		"forall-construct": {
 			"comment": "Introduced in the Fortran 1995 standard.",
-			"contentName": "meta.block.forall.fortran",
-			"begin": "(?i)\\s*\\b(forall)\\b",
-			"beginCaptures":{
+			"begin": "(?i)\\b(forall)\\b",
+			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.forall.fortran"
 				}
 			},
-			"end": "(?i)\\s*\\b(end\\s*forall)\\b",
-			"endCaptures": {
-				"1": {
-					"name": "keyword.control.endforall.fortran"
-				}
-			},
-			"patterns":[
+			"end": "(?<!\\G)",
+			"applyEndPatternLast": 1,
+			"patterns": [
 				{
 					"comment": "Loop control.",
 					"name": "meta.loop-control.fortran",
 					"begin": "(?i)\\G(?!\\s*[;!\\n])",
-					"end": "(?=[;!\\n])",
-					"patterns":[
+					"end": "(?<!\\G)",
+					"patterns": [
 						{
 							"include": "#parentheses"
 						},
@@ -1485,7 +1480,29 @@
 					]
 				},
 				{
-					"include": "$base"
+					"name": "meta.block.forall.fortran",
+					"begin": "(?<=\\))(?=\\s*[;!\\n])",
+					"end": "(?i)\\b(end\\s*forall)\\b",
+					"endCaptures": {
+						"1": {
+							"name": "keyword.control.endforall.fortran"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$base"
+						}
+					]
+				},
+				{
+					"name": "meta.statement.control.forall.fortran",
+					"begin": "(?i)(?<=\\))(?!\\s*[;!\\n])",
+					"end": "\\n",
+					"patterns": [
+						{
+							"include": "$base"
+						}
+					]
 				}
 			]
 		},


### PR DESCRIPTION
This is intended to fix issue #169, which reported that single-line `forall` statements have have incorrect highlighting. The error arrises because the existing patterns assume that all `forall` statements end with an `end forall`. However, this is not true of single-line statements.

This solution follows the already implemented patterns of the `where` statement, which has a very similar syntax.

### Before Change

![Screenshot 2020-04-11 at 06 14 47](https://user-images.githubusercontent.com/8879093/79036018-cc01eb00-7bbb-11ea-8c33-84df27ec2fe6.png)

### After change

![Screenshot 2020-04-11 at 06 13 50](https://user-images.githubusercontent.com/8879093/79036019-ce644500-7bbb-11ea-91af-c98d825427c9.png)

Side note: an identical issue and resolution can be found in a Fortran highligter made for Atom (https://github.com/dparkins/language-fortran/issues/90).



