### PR TITLE
Fix build check

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "CODE_TESTS_WORKSPACE='./' node ./node_modules/vscode/bin/test",
+    "test": "CODE_TESTS_WORKSPACE='./' CODE_DISABLE_EXTENSIONS=1 node ./node_modules/vscode/bin/test",
     "lint": "node ./node_modules/tslint/bin/tslint ./src/**/*.ts "
   },
   "devDependencies": {

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -8,7 +8,7 @@ import { installTool } from './tools';
 // work at all
 export const LANGUAGE_ID = 'FortranFreeForm';
 export const FORTRAN_FREE_FORM_ID = { language: LANGUAGE_ID, scheme: 'file' };
-export { intrinsics }
+export { intrinsics };
 export const EXTENSION_ID = 'fortran';
 
 export const FORTRAN_KEYWORDS = [
@@ -115,7 +115,7 @@ let saveKeywordToJson = keyword => {
   });
 };
 
-export { default as getBinPath } from './paths'
+export { default as getBinPath } from './paths';
 
 export function promptForMissingTool(tool: string) {
   const items = ['Install'];


### PR DESCRIPTION
Try to fix Travis CI checks on extension
Error is:
```shell
TypeError: Cannot read property 'start' of undefined
    at parseSubroutineDefinition (/home/pedro/.vscode/extensions/krvajalm.linter-gfortran-2.1.1/out/src/features/document-symbol-provider.js:64:57)
    at /home/pedro/.vscode/extensions/krvajalm.linter-gfortran-2.1.1/out/src/features/document-symbol-provider.js:31:32
    at Array.map (<anonymous>)
    at FortranDocumentSymbolProvider.<anonymous> (/home/pedro/.vscode/extensions/krvajalm.linter-gfortran-2.1.1/out/src/features/document-symbol-provider.js:31:22)
    at Generator.next (<anonymous>)
    at /home/pedro/.vscode/extensions/krvajalm.linter-gfortran-2.1.1/out/src/features/document-symbol-provider.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/home/pedro/.vscode/extensions/krvajalm.linter-gfortran-2.1.1/out/src/features/document-symbol-provider.js:3:12)
    at FortranDocumentSymbolProvider.parseDoc (/home/pedro/.vscode/extensions/krvajalm.linter-gfortran-2.1.1/out/src/features/document-symbol-provider.js:17:39)
    at FortranDocumentSymbolProvider.provideDocumentSymbols (/home/pedro/.vscode/extensions/krvajalm.linter-gfortran-2.1.1/out/src/features/document-symbol-provider.js:46:35)
(...)

```