### PR TITLE
Support gfortran debugger with debug adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       {
         "id": "fortran_fixed-form",
         "aliases": [
-          "Fortran ",
+          "Fortran",
           "fortran",
           "FORTRAN77"
         ],
@@ -162,7 +162,15 @@
           "description": "Specify the word case to use when suggesting autocomplete options (One of 'lowercase' or 'upercase')"
         }
       }
-    }
+    },
+    "breakpoints": [
+      {
+        "language": "FortranFreeForm"
+      },
+      {
+        "language": "fortran_fixed-form"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",


### PR DESCRIPTION
Add missing `breakpoints` config

Fixes #89