### PR TITLE
Fixed-form highlight: support \t at start of line

### DIFF
--- a/syntaxes/fortran_fixed-form.tmLanguage.json
+++ b/syntaxes/fortran_fixed-form.tmLanguage.json
@@ -56,7 +56,7 @@
                         "end": "(?=\\n)"
                 },
                 "line-header": {
-                        "match": "^(?!\\s*[!#])(?:([ \\d]{5} )|( {5}.)|(.{1,5}))",
+                        "match": "^(?!\\s*[!#])(?:([ \\d]{5} )|( {5}.)|(\\t)|(.{1,5}))",
                         "captures": {
                                 "1": {
                                         "name": "constant.numeric.fortran"
@@ -65,6 +65,9 @@
                                         "name": "keyword.line-continuation-operator.fortran"
                                 },
                                 "3": {
+                                        "name": "source.fortran.free"
+                                },
+                                "4": {
                                         "name": "invalid.error.fortran"
                                 }
                         }


### PR DESCRIPTION
In fixed-form Fortran, \t at the start of a line is the same as 6 white-spaces, which is supported by this modification.