### PR TITLE
Fixes #196.

### DIFF
--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -4648,8 +4648,8 @@
 		"derived-type": {
 			"comment": "Introduced in the Fortran 1995 standard.",
 			"name": "meta.specification.type.derived.fortran",
-			"match": "(?i)\\b(?:(class)|(type))\\s*(\\()\\s*(([a-z]\\w*)|\\*)\\s*(\\))",
-			"captures": {
+			"begin": "(?i)\\b(?:(class)|(type))\\s*(\\()\\s*(([a-z]\\w*)|\\*)",
+			"beginCaptures": {
 				"1": {
 					"name": "storage.type.class.fortran"
 				},
@@ -4661,11 +4661,20 @@
 				},
 				"4": {
 					"name": "entity.name.type.fortran"
-				},
-				"5": {
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
 					"name": "punctuation.parentheses.right.fortran"
 				}
-			}
+			},
+			"contentName": "meta.type-spec.fortran",
+			"patterns": [
+				{
+					"include": "#parentheses-dummy-variables"
+				}
+			]
 		},
 		"logical-type": {
 			"comment": "Introduced in the Fortran 1977 standard.",


### PR DESCRIPTION
Fixes #196 

Changed to a multiline regex where we seek for the ) explicitly.
This seems to have done the trick.
The highlighting for the `name.type` should also now match the
colour of the `name.type` where the type/class defined.
Previously it inherited the colour from (.

Output should now look like this
![image](https://user-images.githubusercontent.com/16143716/99193142-ebbf4a00-276e-11eb-8efc-c95ee7754c08.png)
