### PR TITLE
Adds support for workspace built-in variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#181](https://github.com/krvajal/vscode-fortran-support/issues/181)) via
   ([#218](https://github.com/krvajal/vscode-fortran-support/pull/218))
 
+### Added
+
+- Added capability to resolve `${workspaceFolder}` variable from settings
+  ([#176](https://github.com/krvajal/vscode-fortran-support/issues/176))
+
 ## [2.2.1] - 2020-04-11
 
 ### Fixed


### PR DESCRIPTION
Now VSCode variables `${workspaceFolder}` and `${workspaceRoot}` can be
used in the `settings.json` file to set up include paths and
output directories for the .mod linter files

Fixes #176.
Closes #231 
Possible closure #187 