### PR TITLE
Fixed overzealous OpenMP syntax matching.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Adds support for .f18 and .F18 file extensions
   ([#252](https://github.com/krvajal/vscode-fortran-support/pull/252))
 
+### Fixed
+- Fixed OpenMP syntax accidentally matching OpenACC (See [184](https://github.com/krvajal/vscode-fortran-support/issues/184#issuecomment-920139084))
+
 ## [2.3.0]
 
 ### Fixed

--- a/syntaxes/openmp_lang.json
+++ b/syntaxes/openmp_lang.json
@@ -29,7 +29,7 @@
   "patterns": [
     {
       "name": "meta.openmp.directive",
-      "begin": "(?i)\\G(\\$(omp\\b)?&?)",
+      "begin": "(?i)\\G(\\$(omp\\b)&?)",
       "beginCaptures": { "1": { "name": "comment.directive.openmp" } },
       "end": "(?=[\\n])",
       "patterns": [


### PR DESCRIPTION
Fix for OpenMP syntax highlighting breaking OpenACC. See discussion in https://github.com/krvajal/vscode-fortran-support/issues/184#issuecomment-920139084. 