### PR TITLE
fixed format on save by correcting type problem

### DIFF
--- a/src/features/formatting-provider.ts
+++ b/src/features/formatting-provider.ts
@@ -125,18 +125,23 @@ export class FortranFormattingProvider implements vscode.DocumentFormattingEditP
     const range_whole_file = new vscode.Range(firstLine.range.start, lastline.range.end);
 
     const temp_file = document.fileName + '.findent.tmp';
-
+    const temp_file2 = document.fileName + '.findent.tmp2';
     // Cannot copy file since it hasn't been saved yet!
     // Needs to be synchronous!
-    fs.writeFileSync(temp_file, document.getText(), 'utf8');
+    fs.writeFileSync(temp_file2, document.getText(), 'utf8');
 
-    const args: string = ['< ' + temp_file + ' >', temp_file, ...this.getFormatterArgs()].join(' ');
+    const args: string = ['< ' + temp_file2 + ' >', temp_file, ...this.getFormatterArgs()].join(
+      ' '
+    );
     const command = formatter + ' ' + args;
 
     const process = cp.execSync(command, { stdio: 'inherit' });
 
     const new_file_as_string = fs.readFileSync(temp_file, 'utf8');
     fs.unlink(temp_file, err => {
+      console.log('failed to delete tempfile');
+    });
+    fs.unlink(temp_file2, err => {
       console.log('failed to delete tempfile');
     });
 

--- a/src/features/formatting-provider.ts
+++ b/src/features/formatting-provider.ts
@@ -7,7 +7,12 @@ import * as vscode from 'vscode';
 import * as cp from 'child_process';
 
 import { LoggingService } from '../services/logging-service';
-import { FORMATTERS, EXTENSION_ID, promptForMissingTool } from '../lib/tools';
+import {
+  FORMATTERS,
+  EXTENSION_ID,
+  promptForMissingTool,
+  FortranDocumentSelector,
+} from '../lib/tools';
 
 export class FortranFormattingProvider implements vscode.DocumentFormattingEditProvider {
   constructor(private logger: LoggingService) {}
@@ -20,14 +25,13 @@ export class FortranFormattingProvider implements vscode.DocumentFormattingEditP
     const formatterName: string = this.getFormatter();
 
     if (formatterName === 'fprettify') {
-      this.doFormatFprettify(document);
+      return this.doFormatFprettify(document);
     } else if (formatterName === 'findent') {
-      this.doFormatFindent(document);
+      return this.doFormatFindent(document);
     } else {
       this.logger.logError('Cannot format document with formatter set to Disabled');
+      return null;
     }
-
-    return;
   }
 
   /**
@@ -35,7 +39,10 @@ export class FortranFormattingProvider implements vscode.DocumentFormattingEditP
    *
    * @param document vscode.TextDocument document to operate on
    */
-  private doFormatFprettify(document: vscode.TextDocument) {
+  private doFormatFprettify(
+    document: vscode.TextDocument
+  ): vscode.ProviderResult<vscode.TextEdit[]> {
+    console.log('in fprettify');
     // fprettify can only do FortranFreeFrom
     if (document.languageId !== 'FortranFreeForm') {
       this.logger.logError(`fprettify can only format FortranFreeForm, change
@@ -54,25 +61,37 @@ export class FortranFormattingProvider implements vscode.DocumentFormattingEditP
       promptForMissingTool(formatterName, msg, 'Python', ['Install'], this.logger);
     }
 
-    const args: string[] = [document.fileName, ...this.getFormatterArgs()];
+    // @note Currently we brute force the formatting procedure by creating a tempfile and reading from it once the formatter is finished (synchronously). Fprettify does have a -d flag which won't modify the src file and will output a "diff" file. We could parse that into a TextEdit array in the future
+    //
+
+    const firstLine = document.lineAt(0);
+    const lastline = document.lineAt(document.lineCount - 1);
+    const range_whole_file = new vscode.Range(firstLine.range.start, lastline.range.end);
+
+    const temp_file = document.fileName + '.fprettify.tmp';
+
+    // Cannot copy file since it hasn't been saved yet!
+    // Needs to be synchronous!
+    fs.writeFileSync(temp_file, document.getText(), 'utf8');
+    //fs.copyFileSync(document.fileName, temp_file);
+
+    const args: string[] = [temp_file, ...this.getFormatterArgs()];
+    // could run silent on it
     // args.push('--silent'); // TODO: pass?
 
-    // Get current file (name rel to path), run extension can be in a shell??
-    const process = cp.spawn(formatter, args);
+    const command = formatter + ' ' + args;
 
-    // if the findent then capture the output from that and parse it back to the file
-    process.stdout.on('data', data => {
-      this.logger.logInfo(`formatter stdout: ${data}`);
+    const process = cp.execSync(command, { stdio: 'inherit' });
+    // Enable logging
+
+    const new_file_as_string = fs.readFileSync(temp_file, 'utf8');
+    fs.unlink(temp_file, err => {
+      if (err) {
+        console.log('failed to delete tempfile');
+      }
     });
-    process.stderr.on('data', data => {
-      this.logger.logError(`formatter stderr: ${data}`);
-    });
-    process.on('close', (code: number) => {
-      if (code !== 0) this.logger.logInfo(`formatter exited with code: ${code}`);
-    });
-    process.on('error', code => {
-      this.logger.logInfo(`formatter exited with code: ${code}`);
-    });
+    const new_edit = new vscode.TextEdit(range_whole_file, new_file_as_string);
+    return [new_edit];
   }
 
   /**
@@ -81,10 +100,10 @@ export class FortranFormattingProvider implements vscode.DocumentFormattingEditP
    *
    * @param document vscode.TextDocument document to operate on
    */
-  private doFormatFindent(document: vscode.TextDocument) {
+  private doFormatFindent(document: vscode.TextDocument): vscode.ProviderResult<vscode.TextEdit[]> {
     const formatterName = 'findent';
     const formatterPath: string = this.getFormatterPath();
-    let formatter: string = path.join(formatterPath, formatterName);
+    const formatter: string = path.join(formatterPath, formatterName);
     // If no formatter is detected try and install it
     if (!which.sync(formatter, { nothrow: true })) {
       this.logger.logWarning(`Formatter: ${formatterName} not detected in your system.
@@ -93,21 +112,36 @@ export class FortranFormattingProvider implements vscode.DocumentFormattingEditP
       promptForMissingTool(formatterName, msg, 'Python', ['Install'], this.logger);
     }
 
-    // Annoyingly findent only outputs to a file and not to a stream so
-    // let us go and create a temporary file
-    const out = document.uri.path + '.findent.tmp';
-    const args: string = ['< ' + document.fileName + ' >', out, ...this.getFormatterArgs()].join(
-      ' '
-    );
-    formatter = formatter + ' ' + args;
-
+    // Previous note:
     // @note It is wise to have all IO operations being synchronous we don't
     // want to copy or delete the temp file before findent has completed.
     // I cannot forsee a situation where a performance bottleneck is created
     // since findent performs something like ~100k lines per second
-    cp.execSync(formatter, { stdio: 'inherit' });
-    fs.copyFileSync(out, document.fileName);
-    fs.unlinkSync(out);
+
+    // @note Unlike fprettify we have no option but to brute force for findent since it is old tech! As mentioned above we're not too concerned about bottlenecks
+    //
+    const firstLine = document.lineAt(0);
+    const lastline = document.lineAt(document.lineCount - 1);
+    const range_whole_file = new vscode.Range(firstLine.range.start, lastline.range.end);
+
+    const temp_file = document.fileName + '.findent.tmp';
+
+    // Cannot copy file since it hasn't been saved yet!
+    // Needs to be synchronous!
+    fs.writeFileSync(temp_file, document.getText(), 'utf8');
+
+    const args: string = ['< ' + temp_file + ' >', temp_file, ...this.getFormatterArgs()].join(' ');
+    const command = formatter + ' ' + args;
+
+    const process = cp.execSync(command, { stdio: 'inherit' });
+
+    const new_file_as_string = fs.readFileSync(temp_file, 'utf8');
+    fs.unlink(temp_file, err => {
+      console.log('failed to delete tempfile');
+    });
+
+    const new_edit = new vscode.TextEdit(range_whole_file, new_file_as_string);
+    return [new_edit];
   }
 
   /**


### PR DESCRIPTION
Hey guys,
I noticed an issue with formatting on save when formatting with both fprettify and findent. 

The main issue is that the function 
```
provideDocumentFormattingEdits(
    document: vscode.TextDocument,
    options: vscode.FormattingOptions,
    token: vscode.CancellationToken
  ): vscode.ProviderResult<vscode.TextEdit[]> 
```
needs to return a "TextEdit" element composed of a Range (start and end position in the text) and a new String to replace that Range.

That is to say currently VScode is assuming provideDocumentFormattingEdits does no modifications on the file and returns the necessary changes as an array of changes. By contrast we are returning nothing and doing everything as a side effect. (this is why vscode feels like our files are constantly being modified by a third party because it is)

```
export class FortranFormattingProvider implements vscode.DocumentFormattingEditProvider {
  constructor(private logger: LoggingService) {}

  public provideDocumentFormattingEdits(
    document: vscode.TextDocument,
    options: vscode.FormattingOptions,
    token: vscode.CancellationToken
  ): vscode.ProviderResult<vscode.TextEdit[]> {
    const formatterName: string = this.getFormatter();

    if (formatterName === 'fprettify') {
      this.doFormatFprettify(document);
    } else if (formatterName === 'findent') {
      this.doFormatFindent(document);
    } else {
      this.logger.logError('Cannot format document with formatter set to Disabled');
    }

    return;
  }

  /**
   * Use `fprettify` to format a Fortran file.
   *
   * @param document vscode.TextDocument document to operate on
   */
  private doFormatFprettify(document: vscode.TextDocument) {
    // fprettify can only do FortranFreeFrom
   
    // Function calls Fprettify to modify the source files then returns nothing
  }

```


I did some digging and it seems like a standard solution to connecting CLI formatters to VScode is to simply grab the current state of the document via document.getText(), write it to a tempfile, format it and then return a TextEdit which simply replaces the entire range. I made the required modifications, it currently passes all tests and by 10 minutes of inspection works quite well

I normally program with C/C++ so this is my first time with Typescript that being said was honestly quite a nice experience. 