### PR TITLE
bundle the extension with webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 *.vsix
 .DS_Store
 coverage
+dist
 
 # Fortran files
 *.o

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
-out/test/**
+out
+node_modules
 test/**
 src/**
 **/*.map

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "onLanguage:FortranFreeForm",
     "onLanguage:FortranFixedForm"
   ],
-  "main": "./out/src/extension",
+  "main": "./dist/src/extension",
   "extensionDependencies": [
     "ms-vscode.cpptools"
   ],
@@ -239,7 +239,7 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "webpack --mode production",
     "compile": "tsc -p tsconfig.prod.json",
     "compile-dev": "tsc -p tsconfig.json",
     "watch": "tsc -watch -p tsconfig.prod.json",
@@ -265,6 +265,7 @@
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.10.2",
     "@vscode/test-electron": "^2.1.2",
+    "copy-webpack-plugin": "^10.2.4",
     "eslint": "^8.8.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsdoc": "^37.8.0",
@@ -273,8 +274,11 @@
     "lint-staged": "^12.3.2",
     "mocha": "^9.2.0",
     "prettier": "^2.5.1",
+    "ts-loader": "^9.2.8",
     "typescript": "^4.5.5",
-    "vscode-tmgrammar-test": "^0.0.11"
+    "vscode-tmgrammar-test": "^0.0.11",
+    "webpack": "^5.72.0",
+    "webpack-cli": "^4.9.2"
   },
   "lint-staged": {
     "*.ts": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,58 @@
+//@ts-check
+
+'use strict';
+
+const path = require('path');
+const CopyPlugin = require("copy-webpack-plugin");
+
+/**@type {import('webpack').Configuration}*/
+const config = {
+    // vscode extensions run in a Node.js-context -> https://webpack.js.org/configuration/node/
+    target: 'node',
+
+    plugins: [
+        new CopyPlugin({
+            patterns: [
+                { from: "src/docs", to: "../docs" },
+            ],
+        }),
+    ],
+
+    // the entry point of this extension -> https://webpack.js.org/configuration/entry-context/
+    entry: './src/extension.ts',
+    output: {
+        // the bundle is stored in the 'dist' folder (check package.json) -> https://webpack.js.org/configuration/output/
+        path: path.resolve(__dirname, 'dist', 'src'),
+        filename: 'extension.js',
+        libraryTarget: 'commonjs2',
+        devtoolModuleFilenameTemplate: '../[resource-path]',
+        clean: true
+    },
+    // devtool: 'source-map',
+    externals: {
+        // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed
+        // -> https://webpack.js.org/configuration/externals/
+        vscode: 'commonjs vscode'
+    },
+    resolve: {
+        // support reading TypeScript and JavaScript files -> https://github.com/TypeStrong/ts-loader
+        extensions: ['.ts', '.js']
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            configFile: "tsconfig.prod.json"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+};
+module.exports = config;


### PR DESCRIPTION
Currently , this extension vsix is nearly 10 MB, It discreased to 2MB after bundle and minify it with webpack. Please see the offical information about [bundle](https://code.visualstudio.com/api/working-with-extensions/bundling-extension):

> Bundling Extensions
The first reason to bundle your Visual Studio Code extension is to make sure it works for everyone using VS Code on any platform. Only bundled extensions can be used in VS Code for Web environments like [github.dev](https://github.dev/) and [vscode.dev](https://vscode.dev/). When VS Code is running in the browser, it can only load one file for your extension so the extension code needs to be bundled into one single web-friendly JavaScript file. This also applies to [Notebook Output Renderers](https://code.visualstudio.com/api/extension-guides/notebook#notebook-renderer), where VS Code will also only load one file for your renderer extension.

> In addition, extensions can quickly grow in size and complexity. They may be authored in multiple source files and depend on modules from [npm](https://www.npmjs.com/). Decomposition and reuse are development best practices but they come at a cost when installing and running extensions. Loading 100 small files is much slower than loading one large file. That's why we recommend bundling. Bundling is the process of combining multiple small source files into a single file.

