### PR TITLE
fix(client): #1182 filter out empty extra arguments for fortls extraArgs

### DIFF
--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -223,7 +223,8 @@ export class FortlsClient {
       args.push(`--max_comment_line_length=${maxCommentLineLength}`);
     }
     if (fortlsExtraArgs.length > 0) {
-      args.push(...fortlsExtraArgs);
+      const filteredfortlsExtraArgs = fortlsExtraArgs.filter(item => item.trim().length > 0);
+      args.push(...filteredfortlsExtraArgs);
     }
 
     // Fortran source file parsing


### PR DESCRIPTION
Empty variable in the ExtraArgs list are included into the global argument list and then `fortls` try to parse it. Here is the simple example which reproduce the problem:
```
#file:./.vscode/settings.json
    "fortran.fortls.extraArgs": [
        "--max_comment_line_length=500",
        "",
        "",
        "",
        "",
        "--max_line_length=500",
    ],
```
The Output panel of "Modern Fortran" shows the following error:
<img width="1338" height="860" alt="image" src="https://github.com/user-attachments/assets/140273e1-ebb2-4d89-ae37-060ebf65d1ed" />

If we filter the argument list eliminating empty arguments the problem is dissappearing:
<img width="1302" height="297" alt="image" src="https://github.com/user-attachments/assets/75462712-bc51-47b3-91c1-a6c1f3882cad" />
