### PR TITLE
fix(fypp): erroneous warning for fypp

### DIFF
--- a/src/lint/provider.ts
+++ b/src/lint/provider.ts
@@ -135,11 +135,12 @@ export class LinterSettings {
 
   public get fyppEnabled(): boolean {
     // FIXME: fypp currently works only with gfortran
-    if (this.compiler !== 'gfortran') {
+    const isEnabled = this.config.get<boolean>('linter.fypp.enabled');
+    if (this.compiler !== 'gfortran' && isEnabled) {
       this.logger.warn(`[lint] fypp currently only supports gfortran.`);
       return false;
     }
-    return this.config.get<boolean>('linter.fypp.enabled');
+    return isEnabled;
   }
   public get fyppPath(): string {
     return this.config.get<string>('linter.fypp.path');


### PR DESCRIPTION
Previously the extension logged warnings regardless
of whether fypp was enabled or not due to
the linting compiler being different.

Fixes #1017
