### PR TITLE
feat!: environment aware python installations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
+        "@vscode/python-extension": "1.0.5",
         "glob": "^11.1.0",
         "semver": "^7.7.3",
         "vscode-languageclient": "^8.1.0",
@@ -22,7 +23,7 @@
         "@types/mocha": "^10.0.6",
         "@types/node": "^22.13.0",
         "@types/semver": "^7.7.1",
-        "@types/vscode": "^1.67.0",
+        "@types/vscode": "^1.78.0",
         "@types/which": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^8.52.0",
         "@typescript-eslint/parser": "^8.29.1",
@@ -48,7 +49,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.78.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1526,6 +1527,16 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vscode/python-extension": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@vscode/python-extension/-/python-extension-1.0.5.tgz",
+      "integrity": "sha512-uYhXUrL/gn92mfqhjAwH2+yGOpjloBxj9ekoL4BhUsKcyJMpEg6WlNf3S3si+5x9zlbHHe7FYQNjZEbz1ymI9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.17.1",
+        "vscode": "^1.78.0"
       }
     },
     "node_modules/@vscode/test-cli": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.67.0"
+    "vscode": "^1.78.0"
   },
   "icon": "assets/png/icon.png",
   "homepage": "https://github.com/fortran-lang/vscode-fortran-support#readme",
@@ -763,7 +763,7 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "^22.13.0",
     "@types/semver": "^7.7.1",
-    "@types/vscode": "^1.67.0",
+    "@types/vscode": "^1.78.0",
     "@types/which": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^8.52.0",
     "@typescript-eslint/parser": "^8.29.1",
@@ -796,6 +796,7 @@
     ]
   },
   "dependencies": {
+    "@vscode/python-extension": "1.0.5",
     "glob": "^11.1.0",
     "semver": "^7.7.3",
     "vscode-languageclient": "^8.1.0",

--- a/src/util/python-installer.ts
+++ b/src/util/python-installer.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+
+import { spawnAsPromise } from './tools';
+
+const PYTHON_EXTENSION_ID = 'ms-python.python';
+// TODO: add pretty output Log channel or maybe progress notification?
+// TODO: Creates a schism between installation and detection/usage of binaries
+//       the detection/usage should also leverage the python extension
+// TODO: All of these functions watch for change events in the python extension
+/**
+ * Get Python executable from ms-python.python extension if available, otherwise fallback.
+ * @param resource Optional URI to determine workspace-specific environment
+ * @returns Python executable path or undefined
+ */
+async function getPythonExecutable(resource?: vscode.Uri): Promise<string | undefined> {
+  const pyExt = vscode.extensions.getExtension(PYTHON_EXTENSION_ID);
+  if (!pyExt) return undefined;
+
+  if (!pyExt.isActive) {
+    await pyExt.activate();
+  }
+
+  // Import type only when extension is available
+  const { PythonExtension } = await import('@vscode/python-extension');
+  const api = await PythonExtension.api();
+
+  const envPath = api.environments.getActiveEnvironmentPath(resource);
+  if (!envPath) return undefined;
+
+  const env = await api.environments.resolveEnvironment(envPath);
+  return env?.executable.uri?.fsPath;
+}
+
+/**
+ * Install Python package using pip with ms-python.python integration.
+ * Falls back to system Python if extension unavailable.
+ * @param pyPackage name of python package in PyPi
+ * @param resource Optional URI for workspace-specific environment selection
+ * @returns Success message
+ */
+export async function installPythonPackage(
+  pyPackage: string,
+  resource?: vscode.Uri
+): Promise<string> {
+  let pythonExe = await getPythonExecutable(resource);
+
+  // Fallback to system Python
+  if (!pythonExe) {
+    const candidates = ['python3', 'py', 'python'];
+    for (const cmd of candidates) {
+      try {
+        await spawnAsPromise(cmd, ['--version'], { windowsHide: true });
+        pythonExe = cmd;
+        break;
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  if (!pythonExe) {
+    throw new Error('No Python interpreter found');
+  }
+
+  const args = ['-m', 'pip', 'install', '--upgrade', pyPackage];
+
+  try {
+    // Virtual environments do not support user installs
+    // the first attempt is "global"
+    await spawnAsPromise(pythonExe, args, { windowsHide: true });
+  } catch {
+    // Retry with --user for permission-restricted environments
+    await spawnAsPromise(pythonExe, [...args, '--user'], { windowsHide: true });
+  }
+  // TODO: needs better returns, strings are lazy programming
+  return `Successfully installed ${pyPackage}`;
+}

--- a/src/util/tools.ts
+++ b/src/util/tools.ts
@@ -141,6 +141,7 @@ export async function promptForMissingTool(
  * A wrapper around a call to `pip` for installing external tools.
  * Does not explicitly check if `pip` is installed.
  *
+ * @deprecated Use `installPythonPackage` from python-installer.ts for better virtual environment support
  * @param pyPackage name of python package in PyPi
  */
 export async function pipInstall(pyPackage: string): Promise<string> {


### PR DESCRIPTION
Leverages the `ms-python.python` extension and its node API
in order to softly detect if the extension is present.
If present it will activate it, search for the "correct" environment
and install the package there.

The choice of the environment is purely dependant on the rules
imposed in `ms-python.python`. The user can select an interpreter
via the the command palette, but this is a suboptimal Fortran user
experience, since detection and messages about missing fortls
pop up before the user can do that (realistically at least).

In addition, changes in Python environments are not propagated.
Watch events need to be added and detection/installation/execution
needs be redone in such cases.

This only takes care of the installation process but does nothing
for the detection/execution of the binaries. Consequently, if replacing
naively `pipInstall` with `installPythonPackage` things will fail.

The detection, execution and installation need to me rewritten
in a cohesive way without duplication.
Paths need to be cached and resolve wrt user inputs from the configs.

For multi-root workspaces, with different Python environments this
could trigger a cascade of installs, which might or might not be the
intended behaviour.

BREAKING CHANGE: using `@vscode/python-extension` requires bumping the minimum vscode engine and types to ^1.78.0.

Outdated vscode installations will not work anymore!

Fixes #1273
