### PR TITLE
Feat: Dim inactive preprocessor regions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,12 @@
             ],
             "markdownDescription": "The log level for the extension.",
             "order": 70
+          },
+          "fortran.preprocessor.dimInactiveRegions": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Dim inactive preprocessor regions using the macro definitions configured for `fortls`. Supports `#ifdef`, `#ifndef`, `#if`, and `#elif` when the condition is an integer literal, a bare macro name, or `defined(MACRO)`.",
+            "order": 80
           }
         }
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { WhatsNew } from './commands/commands';
 import { FortranCompletionProvider } from './fallback-features/completion-provider';
 import { FortranDocumentSymbolProvider } from './fallback-features/document-symbol-provider';
 import { FortranHoverProvider } from './fallback-features/hover-provider';
+import { InactivePreprocessorProvider } from './fallback-features/inactive-preprocessor-provider';
 import { FortranFormattingProvider } from './format/provider';
 import { FortranLintingProvider } from './lint/provider';
 import { FortlsClient } from './lsp/client';
@@ -77,6 +78,9 @@ export async function activate(context: vscode.ExtensionContext) {
     const symbolProvider = new FortranDocumentSymbolProvider();
     vscode.languages.registerDocumentSymbolProvider(FortranDocumentSelector(), symbolProvider);
   }
+
+  const inactivePreprocessorProvider = new InactivePreprocessorProvider(logger);
+  context.subscriptions.push(...inactivePreprocessorProvider.activate());
 
   if (!config.get<boolean>('fortls.disabled')) {
     new FortlsClient(logger, context).activate();

--- a/src/fallback-features/inactive-preprocessor-provider.ts
+++ b/src/fallback-features/inactive-preprocessor-provider.ts
@@ -1,0 +1,291 @@
+import * as vscode from 'vscode';
+
+import { Logger } from '../services/logging';
+import { EXTENSION_ID, isFortran } from '../util/tools';
+
+interface PreprocessorBlockState {
+  parentActive: boolean;
+  hasTakenBranch: boolean;
+  currentActive: boolean;
+}
+
+const INACTIVE_PREPROCESSOR_REGEX = /^\s*#[:]?\s*(if|ifdef|ifndef|elif|else|endif)\b(?:\s+(.*))?$/i;
+
+/**
+ * Evaluates the limited preprocessor conditions supported by inactive-region dimming.
+ *
+ * Supported forms are a bare macro identifier (`FOO`), `defined(FOO)`, and
+ * integer literals where `0` is false and any non-zero value is true. Any other
+ * expression shape is treated as unsupported and therefore false.
+ *
+ * @param conditionText Raw text following a `#if` or `#elif` directive.
+ * @param definedMacros Set of macro names currently considered defined.
+ * @returns `true` when the condition is supported and matches a defined macro.
+ */
+export function evaluatePreprocessorCondition(
+  conditionText: string | undefined,
+  definedMacros: ReadonlySet<string>
+): boolean {
+  if (!conditionText) {
+    return false;
+  }
+
+  const trimmedCondition = conditionText.trim();
+  const integerLiteral = trimmedCondition.match(/^[+-]?\d+$/);
+  if (integerLiteral) {
+    return Number.parseInt(trimmedCondition, 10) !== 0;
+  }
+
+  const definedMatch = trimmedCondition.match(/^defined\s*\(\s*([A-Za-z_]\w*)\s*\)$/i);
+  if (definedMatch) {
+    return definedMacros.has(definedMatch[1]);
+  }
+
+  const bareMacroMatch = trimmedCondition.match(/^([A-Za-z_]\w*)$/);
+  if (bareMacroMatch) {
+    return definedMacros.has(bareMacroMatch[1]);
+  }
+
+  return false;
+}
+
+/**
+ * Converts configured preprocessor definitions into the macro-name set used by
+ * the inactive-region evaluator.
+ *
+ * Values are intentionally ignored; for this feature a macro is either defined
+ * or not defined.
+ *
+ * @param definitions `fortls.preprocessor.definitions` from workspace settings.
+ * @returns Set of defined macro names.
+ */
+export function collectDefinedPreprocessorMacros(
+  definitions: Record<string, string> | undefined
+): Set<string> {
+  if (!definitions) {
+    return new Set<string>();
+  }
+
+  return new Set(Object.keys(definitions));
+}
+
+/**
+ * Scans a Fortran document for preprocessor blocks and returns the code ranges
+ * that belong to inactive branches.
+ *
+ * Directive lines themselves are excluded from the returned ranges so only the
+ * inactive Fortran code is dimmed in the editor.
+ *
+ * @param document The document to inspect.
+ * @param definedMacros Set of macro names currently considered defined.
+ * @returns Editor ranges that should be rendered as inactive.
+ */
+export function computeInactivePreprocessorRanges(
+  document: vscode.TextDocument,
+  definedMacros: ReadonlySet<string>
+): vscode.Range[] {
+  const ranges: vscode.Range[] = [];
+  const stack: PreprocessorBlockState[] = [];
+  let inactiveStartLine: number | undefined;
+  let currentActive = true;
+
+  const closeInactiveRange = (endLine: number) => {
+    if (inactiveStartLine === undefined || endLine < inactiveStartLine) {
+      inactiveStartLine = undefined;
+      return;
+    }
+
+    const endCharacter = document.lineAt(endLine).range.end.character;
+    ranges.push(new vscode.Range(inactiveStartLine, 0, endLine, endCharacter));
+    inactiveStartLine = undefined;
+  };
+
+  const updateCurrentActive = () => {
+    currentActive = stack.length > 0 ? stack[stack.length - 1].currentActive : true;
+  };
+
+  for (let lineNumber = 0; lineNumber < document.lineCount; lineNumber++) {
+    const line = document.lineAt(lineNumber).text;
+    const directiveMatch = line.match(INACTIVE_PREPROCESSOR_REGEX);
+
+    if (directiveMatch) {
+      closeInactiveRange(lineNumber - 1);
+
+      const directive = directiveMatch[1].toLowerCase();
+      const directiveArgument = directiveMatch[2];
+
+      if (directive === 'if' || directive === 'ifdef' || directive === 'ifndef') {
+        const parentActive = currentActive;
+        let branchCondition = false;
+
+        if (directive === 'if') {
+          branchCondition = evaluatePreprocessorCondition(directiveArgument, definedMacros);
+        } else {
+          const macroNameMatch = directiveArgument?.match(/^\s*([A-Za-z_]\w*)\s*$/);
+          const macroName = macroNameMatch?.[1];
+          const isDefined = macroName ? definedMacros.has(macroName) : false;
+          branchCondition = directive === 'ifdef' ? isDefined : !isDefined;
+        }
+
+        stack.push({
+          parentActive,
+          hasTakenBranch: branchCondition,
+          currentActive: parentActive && branchCondition,
+        });
+        updateCurrentActive();
+        continue;
+      }
+
+      if (directive === 'elif') {
+        const currentBlock = stack[stack.length - 1];
+        if (currentBlock) {
+          const branchCondition =
+            !currentBlock.hasTakenBranch &&
+            evaluatePreprocessorCondition(directiveArgument, definedMacros);
+          currentBlock.currentActive = currentBlock.parentActive && branchCondition;
+          currentBlock.hasTakenBranch = currentBlock.hasTakenBranch || branchCondition;
+          updateCurrentActive();
+        }
+        continue;
+      }
+
+      if (directive === 'else') {
+        const currentBlock = stack[stack.length - 1];
+        if (currentBlock) {
+          currentBlock.currentActive = currentBlock.parentActive && !currentBlock.hasTakenBranch;
+          currentBlock.hasTakenBranch = true;
+          updateCurrentActive();
+        }
+        continue;
+      }
+
+      if (directive === 'endif') {
+        if (stack.length > 0) {
+          stack.pop();
+          updateCurrentActive();
+        }
+      }
+
+      continue;
+    }
+
+    if (!currentActive && inactiveStartLine === undefined) {
+      inactiveStartLine = lineNumber;
+      continue;
+    }
+
+    if (currentActive) {
+      closeInactiveRange(lineNumber - 1);
+    }
+  }
+
+  closeInactiveRange(document.lineCount - 1);
+  return ranges;
+}
+
+/**
+ * Keeps inactive preprocessor regions dimmed in visible Fortran editors by
+ * recomputing decorations when documents, editors, or relevant settings change.
+ */
+export class InactivePreprocessorProvider implements vscode.Disposable {
+  private readonly decorationType = vscode.window.createTextEditorDecorationType({
+    isWholeLine: true,
+    opacity: '0.4',
+    rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+  });
+
+  private readonly disposables: vscode.Disposable[] = [];
+
+  /**
+   * @param logger Extension logger used for debug tracing during refreshes.
+   */
+  constructor(private readonly logger: Logger) {}
+
+  /**
+   * Registers editor/document/configuration listeners and performs the initial
+   * refresh for all visible editors.
+   *
+   * @returns The provider instance so it can be tracked by the extension lifecycle.
+   */
+  public activate(): vscode.Disposable[] {
+    this.disposables.push(
+      vscode.window.onDidChangeActiveTextEditor(editor => {
+        if (editor) {
+          this.refreshEditor(editor);
+        }
+      }),
+      vscode.window.onDidChangeVisibleTextEditors(editors => {
+        editors.forEach(editor => this.refreshEditor(editor));
+      }),
+      vscode.workspace.onDidOpenTextDocument(document => {
+        this.refreshVisibleEditors(document);
+      }),
+      vscode.workspace.onDidChangeTextDocument(event => {
+        this.refreshVisibleEditors(event.document);
+      }),
+      vscode.workspace.onDidCloseTextDocument(document => {
+        this.refreshVisibleEditors(document);
+      }),
+      vscode.workspace.onDidChangeConfiguration(event => {
+        if (
+          event.affectsConfiguration(`${EXTENSION_ID}.preprocessor.dimInactiveRegions`) ||
+          event.affectsConfiguration(`${EXTENSION_ID}.fortls.preprocessor.definitions`)
+        ) {
+          this.refreshAllVisibleEditors();
+        }
+      })
+    );
+
+    this.refreshAllVisibleEditors();
+    return [this];
+  }
+
+  /**
+   * Releases the decoration type and all event subscriptions owned by the provider.
+   */
+  public dispose() {
+    this.decorationType.dispose();
+    this.disposables.forEach(disposable => disposable.dispose());
+  }
+
+  private refreshAllVisibleEditors() {
+    vscode.window.visibleTextEditors.forEach(editor => this.refreshEditor(editor));
+  }
+
+  private refreshVisibleEditors(document: vscode.TextDocument) {
+    vscode.window.visibleTextEditors
+      .filter(editor => editor.document.uri.toString() === document.uri.toString())
+      .forEach(editor => this.refreshEditor(editor));
+  }
+
+  /**
+   * Recomputes inactive ranges for a single editor and updates its decorations.
+   *
+   * @param editor The editor to refresh.
+   */
+  private refreshEditor(editor: vscode.TextEditor) {
+    if (!isFortran(editor.document) || !this.isEnabled()) {
+      editor.setDecorations(this.decorationType, []);
+      return;
+    }
+
+    const macroDefinitions =
+      vscode.workspace
+        .getConfiguration(`${EXTENSION_ID}.fortls.preprocessor`)
+        .get<Record<string, string>>('definitions') ?? {};
+    const definedMacros = collectDefinedPreprocessorMacros(macroDefinitions);
+    const ranges = computeInactivePreprocessorRanges(editor.document, definedMacros);
+
+    this.logger.debug('[inactive-preprocessor] Refreshing inactive preprocessor regions', {
+      uri: editor.document.uri.toString(),
+      ranges: ranges.length,
+    });
+    editor.setDecorations(this.decorationType, ranges);
+  }
+
+  private isEnabled(): boolean {
+    return vscode.workspace
+      .getConfiguration(EXTENSION_ID)
+      .get<boolean>('preprocessor.dimInactiveRegions', true);
+  }
+}

--- a/test/unitTest/inactive-preprocessor-provider.test.ts
+++ b/test/unitTest/inactive-preprocessor-provider.test.ts
@@ -1,0 +1,246 @@
+import { strictEqual } from 'assert';
+
+import * as vscode from 'vscode';
+
+import {
+  collectDefinedPreprocessorMacros,
+  computeInactivePreprocessorRanges,
+  evaluatePreprocessorCondition,
+} from '../../src/fallback-features/inactive-preprocessor-provider';
+
+suite('inactive preprocessor provider', () => {
+  test('collectDefinedPreprocessorMacros returns configured macro names', () => {
+    const macros = collectDefinedPreprocessorMacros({
+      FOO: '1',
+      BAR: '',
+    });
+
+    strictEqual(macros.has('FOO'), true);
+    strictEqual(macros.has('BAR'), true);
+    strictEqual(macros.has('BAZ'), false);
+  });
+
+  test('evaluatePreprocessorCondition supports bare macro names and defined(MACRO)', () => {
+    const macros = new Set<string>(['FOO', 'BAR']);
+
+    strictEqual(evaluatePreprocessorCondition('0', macros), false);
+    strictEqual(evaluatePreprocessorCondition('1', macros), true);
+    strictEqual(evaluatePreprocessorCondition('2', macros), true);
+    strictEqual(evaluatePreprocessorCondition('-1', macros), true);
+    strictEqual(evaluatePreprocessorCondition('FOO', macros), true);
+    strictEqual(evaluatePreprocessorCondition('BAZ', macros), false);
+    strictEqual(evaluatePreprocessorCondition('defined(FOO)', macros), true);
+    strictEqual(evaluatePreprocessorCondition('defined(BAZ)', macros), false);
+  });
+
+  test('evaluatePreprocessorCondition rejects unsupported expressions', () => {
+    const macros = new Set<string>(['FOO', 'BAR']);
+
+    strictEqual(evaluatePreprocessorCondition('defined(FOO) && defined(BAR)', macros), false);
+    strictEqual(evaluatePreprocessorCondition('FOO == 1', macros), false);
+    strictEqual(evaluatePreprocessorCondition('!defined(FOO)', macros), false);
+  });
+
+  test('computeInactivePreprocessorRanges dims false #ifdef branch', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: ['#ifdef FOO', 'print *, "foo"', '#else', 'print *, "bar"', '#endif'].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>());
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 1);
+    strictEqual(ranges[0].end.line, 1);
+  });
+
+  test('computeInactivePreprocessorRanges dims false #ifndef branch', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: ['#ifndef FOO', 'print *, "foo"', '#else', 'print *, "bar"', '#endif'].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['FOO']));
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 1);
+    strictEqual(ranges[0].end.line, 1);
+  });
+
+  test('computeInactivePreprocessorRanges handles nested inactive regions', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: [
+        '#ifdef OUTER',
+        'print *, "outer"',
+        '#ifdef INNER',
+        'print *, "inner"',
+        '#else',
+        'print *, "inner else"',
+        '#endif',
+        '#endif',
+      ].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['OUTER']));
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 3);
+    strictEqual(ranges[0].end.line, 3);
+  });
+
+  test('computeInactivePreprocessorRanges ignores directive lines themselves', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: ['#ifdef FOO', '#else', 'print *, "bar"', '#endif'].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['FOO']));
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 2);
+    strictEqual(ranges[0].end.line, 2);
+  });
+
+  test('computeInactivePreprocessorRanges activates matching #elif branch', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: [
+        '#ifdef FOO',
+        'print *, "foo"',
+        '#elif BAR',
+        'print *, "bar"',
+        '#else',
+        'print *, "fallback"',
+        '#endif',
+      ].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['BAR']));
+
+    strictEqual(ranges.length, 2);
+    strictEqual(ranges[0].start.line, 1);
+    strictEqual(ranges[0].end.line, 1);
+    strictEqual(ranges[1].start.line, 5);
+    strictEqual(ranges[1].end.line, 5);
+  });
+
+  test('computeInactivePreprocessorRanges supports #elif defined(MACRO)', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: [
+        '#ifdef FOO',
+        'print *, "foo"',
+        '#elif defined(BAR)',
+        'print *, "bar"',
+        '#else',
+        'print *, "fallback"',
+        '#endif',
+      ].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['BAR']));
+
+    strictEqual(ranges.length, 2);
+    strictEqual(ranges[0].start.line, 1);
+    strictEqual(ranges[0].end.line, 1);
+    strictEqual(ranges[1].start.line, 5);
+    strictEqual(ranges[1].end.line, 5);
+  });
+
+  test('computeInactivePreprocessorRanges supports #if MACRO', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: ['#if FOO', 'print *, "foo"', '#else', 'print *, "fallback"', '#endif'].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['FOO']));
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 3);
+    strictEqual(ranges[0].end.line, 3);
+  });
+
+  test('computeInactivePreprocessorRanges supports #if defined(MACRO)', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: [
+        '#if defined(FOO)',
+        'print *, "foo"',
+        '#else',
+        'print *, "fallback"',
+        '#endif',
+      ].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['FOO']));
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 3);
+    strictEqual(ranges[0].end.line, 3);
+  });
+
+  test('computeInactivePreprocessorRanges treats unsupported #if expressions as inactive', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: [
+        '#if defined(FOO) && defined(BAR)',
+        'print *, "complex"',
+        '#else',
+        'print *, "fallback"',
+        '#endif',
+      ].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>(['FOO', 'BAR']));
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 1);
+    strictEqual(ranges[0].end.line, 1);
+  });
+
+  test('computeInactivePreprocessorRanges supports #elif 1', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: [
+        '#if defined(FOO)',
+        'print *, "foo"',
+        '#elif 1',
+        'print *, "fallback"',
+        '#endif',
+      ].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>());
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 1);
+    strictEqual(ranges[0].end.line, 1);
+  });
+
+  test('computeInactivePreprocessorRanges supports #if 0', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: ['#if 0', 'print *, "inactive"', '#else', 'print *, "active"', '#endif'].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>());
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 1);
+    strictEqual(ranges[0].end.line, 1);
+  });
+
+  test('computeInactivePreprocessorRanges supports non-zero integer literals', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'FortranFreeForm',
+      content: ['#if 2', 'print *, "active"', '#else', 'print *, "inactive"', '#endif'].join('\n'),
+    });
+
+    const ranges = computeInactivePreprocessorRanges(document, new Set<string>());
+
+    strictEqual(ranges.length, 1);
+    strictEqual(ranges[0].start.line, 3);
+    strictEqual(ranges[0].end.line, 3);
+  });
+});


### PR DESCRIPTION
This commit adds a new feature to Modern Fortran VSCode plugin: dim inactivate preprocessor regions using the marco definitions configured for fortls.

To keep this feature as simple as possible, only conditions is an integer literal, a bare marco name or "defined(MARCO)" is supported, like:

- #if 1
- #ifdef TEST
- #ifndef TEST
- #if defined(TEST)
- #elif 1

A new setting is added to switch this feature on/off, and related unit tests is also added.